### PR TITLE
feat: inbox/outbox symmetry - per-server outbox structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,14 @@
 # ==============================================================================
-# SYNC-SHUTTLE .gitignore
+# BUCKETCAST .gitignore
 # ==============================================================================
 
 # ==============================================================================
 # Runtime Data (Never commit user data)
 # ==============================================================================
 # The entire runtime directory - contains user files, logs, configs
-~/.sync-shuttle/
+~/.bucketcast/
 
-# If someone clones into their sync-shuttle runtime dir (edge case)
+# If someone clones into their bucketcast runtime dir (edge case)
 remote/
 local/
 logs/
@@ -16,9 +16,9 @@ archive/
 tmp/
 
 # User config files (contain server credentials/paths)
-config/sync-shuttle.conf
+config/bucketcast.conf
 config/servers.conf
-.syncshuttlerc
+.bucketcastrc
 
 # ==============================================================================
 # Logs
@@ -141,8 +141,8 @@ build/
 # Testing
 # ==============================================================================
 # Test output directories (created by mktemp)
-/tmp/sync-shuttle-test*/
-/tmp/sync-shuttle-tests/
+/tmp/bucketcast-test*/
+/tmp/bucketcast-tests/
 
 # Coverage reports
 coverage/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ curl -fsSL https://raw.githubusercontent.com/kaurifund/bucketcast/main/install.s
 
 That's it. This installs to `~/.local/share/sync-shuttle/`, adds it to your PATH, and sets up everything including the TUI.
 
+### Install from a branch
+
+To test a feature branch before it's merged:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/kaurifund/bucketcast/BRANCH_NAME/install.sh | bash
+```
+
+Replace `BRANCH_NAME` with the branch (e.g., `feature/outbox-inbox-symmetry`).
+
 ---
 
 Sync Shuttle is a command-line tool for safely transferring files between your home computer and remote servers. It prioritizes safety and auditability over speed, ensuring files are never accidentally deleted or overwritten.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ After initialization, Sync Shuttle creates:
 | `init` | Initialize directory structure |
 | `push` | Push files TO a remote server |
 | `pull` | Pull files FROM a remote server |
+| `share` | Share files via outbox (for others to pull) |
 | `list servers` | List configured servers |
 | `list files` | List files for a server |
 | `status` | Show sync status |
@@ -103,6 +104,9 @@ After initialization, Sync Shuttle creates:
 | `-v, --verbose` | Verbose output |
 | `-q, --quiet` | Minimal output |
 | `--s3-archive` | Archive to S3 after sync |
+| `--global` | Share with all servers (share command) |
+| `--list` | List shared files (share command) |
+| `--remove` | Remove from share (share command) |
 
 ### Examples
 
@@ -124,6 +128,18 @@ sync-shuttle.sh push -s myserver -S ~/updated.txt --force
 
 # With S3 archival
 sync-shuttle.sh push -s myserver -S ~/backup/ --s3-archive
+
+# Share a file globally (all servers can pull)
+sync-shuttle share --global -S ~/shared-doc.pdf
+
+# Share with a specific server
+sync-shuttle share -s myserver -S ~/for-myserver.txt
+
+# List all shared files
+sync-shuttle share --list
+
+# Remove a file from global share
+sync-shuttle share --global --remove -S shared-doc.pdf
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ After initialization, Sync Shuttle creates:
 │       └── files/           # Files synced with this server
 ├── local/
 │   ├── inbox/               # Files received from remotes
-│   └── outbox/              # Files staged for sending
+│   │   └── <server_id>/     # Per-server incoming files
+│   └── outbox/              # Files shared with remotes
+│       ├── global/          # Available to all servers
+│       └── <server_id>/     # Server-specific shares
 ├── logs/
 │   ├── sync.log             # Human-readable log
 │   └── sync.jsonl           # JSON Lines log

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sync Shuttle
+# Bucketcast
 
 **Safe, Idempotent File Synchronization for Manual Transfers**
 
@@ -8,7 +8,7 @@
 curl -fsSL https://raw.githubusercontent.com/kaurifund/bucketcast/main/install.sh | bash
 ```
 
-That's it. This installs to `~/.local/share/sync-shuttle/`, adds it to your PATH, and sets up everything including the TUI.
+That's it. This installs to `~/.local/share/bucketcast/`, adds it to your PATH, and sets up everything including the TUI.
 
 ### Install from a branch
 
@@ -22,12 +22,12 @@ Replace `BRANCH_NAME` with the branch (e.g., `feature/outbox-inbox-symmetry`).
 
 ---
 
-Sync Shuttle is a command-line tool for safely transferring files between your home computer and remote servers. It prioritizes safety and auditability over speed, ensuring files are never accidentally deleted or overwritten.
+Bucketcast is a command-line tool for safely transferring files between your home computer and remote servers. It prioritizes safety and auditability over speed, ensuring files are never accidentally deleted or overwritten.
 
 ## Features
 
 - 🔒 **Safe by Design**: Never deletes files, never overwrites without consent
-- 📁 **Sandboxed Operations**: All files stored in `~/.sync-shuttle/`
+- 📁 **Sandboxed Operations**: All files stored in `~/.bucketcast/`
 - 🔄 **Bidirectional Sync**: Push to and pull from remote servers
 - 📝 **Comprehensive Logging**: JSON and human-readable logs
 - 🎯 **Idempotent**: Safe to run multiple times
@@ -42,13 +42,13 @@ curl -fsSL https://raw.githubusercontent.com/kaurifund/bucketcast/main/install.s
 source ~/.bashrc  # or restart your shell
 
 # 2. Configure a server
-nano ~/.sync-shuttle/config/servers.toml
+nano ~/.bucketcast/config/servers.toml
 
 # 3. Test with dry-run
-sync-shuttle push --server myserver --source ~/myfile.txt --dry-run
+bucketcast push --server myserver --source ~/myfile.txt --dry-run
 
 # 4. Execute
-sync-shuttle push --server myserver --source ~/myfile.txt
+bucketcast push --server myserver --source ~/myfile.txt
 ```
 
 ## Requirements
@@ -65,12 +65,12 @@ sync-shuttle push --server myserver --source ~/myfile.txt
 
 ## Directory Structure
 
-After initialization, Sync Shuttle creates:
+After initialization, Bucketcast creates:
 
 ```
-~/.sync-shuttle/
+~/.bucketcast/
 ├── config/
-│   ├── sync-shuttle.conf    # Main configuration
+│   ├── bucketcast.conf    # Main configuration
 │   └── servers.toml         # Server definitions
 ├── remote/
 │   └── <server_id>/
@@ -122,41 +122,41 @@ After initialization, Sync Shuttle creates:
 
 ```bash
 # Push a single file
-sync-shuttle.sh push -s myserver -S ~/document.pdf
+bucketcast.sh push -s myserver -S ~/document.pdf
 
 # Push a directory
-sync-shuttle.sh push -s myserver -S ~/projects/myapp/
+bucketcast.sh push -s myserver -S ~/projects/myapp/
 
 # Pull from a server
-sync-shuttle.sh pull -s myserver
+bucketcast.sh pull -s myserver
 
 # Dry-run (always recommended first!)
-sync-shuttle.sh push -s myserver -S ~/data.zip --dry-run
+bucketcast.sh push -s myserver -S ~/data.zip --dry-run
 
 # Force overwrite (archives existing)
-sync-shuttle.sh push -s myserver -S ~/updated.txt --force
+bucketcast.sh push -s myserver -S ~/updated.txt --force
 
 # With S3 archival
-sync-shuttle.sh push -s myserver -S ~/backup/ --s3-archive
+bucketcast.sh push -s myserver -S ~/backup/ --s3-archive
 
 # Share a file globally (all servers can pull)
-sync-shuttle share --global -S ~/shared-doc.pdf
+bucketcast share --global -S ~/shared-doc.pdf
 
 # Share with a specific server
-sync-shuttle share -s myserver -S ~/for-myserver.txt
+bucketcast share -s myserver -S ~/for-myserver.txt
 
 # List all shared files
-sync-shuttle share --list
+bucketcast share --list
 
 # Remove a file from global share
-sync-shuttle share --global --remove -S shared-doc.pdf
+bucketcast share --global --remove -S shared-doc.pdf
 ```
 
 ## Configuration
 
 ### Server Configuration
 
-Edit `~/.sync-shuttle/config/servers.toml`:
+Edit `~/.bucketcast/config/servers.toml`:
 
 ```toml
 [servers.myserver]
@@ -165,7 +165,7 @@ host = "192.168.1.100"
 port = 22
 user = "myuser"
 identity_file = "~/.ssh/id_rsa"  # optional
-remote_base = "/home/myuser/.sync-shuttle"
+remote_base = "/home/myuser/.bucketcast"
 enabled = true
 s3_backup = false
 
@@ -175,14 +175,14 @@ host = "ec2-12-34-56-78.compute-1.amazonaws.com"
 port = 22
 user = "ec2-user"
 identity_file = "~/.ssh/my-key.pem"
-remote_base = "/home/ec2-user/.sync-shuttle"
+remote_base = "/home/ec2-user/.bucketcast"
 enabled = true
 s3_backup = true
 ```
 
 ### Main Configuration
 
-Edit `~/.sync-shuttle/config/sync-shuttle.conf`:
+Edit `~/.bucketcast/config/bucketcast.conf`:
 
 ```bash
 # Log level: DEBUG, INFO, WARN, ERROR
@@ -197,12 +197,12 @@ ARCHIVE_RETENTION_DAYS=30
 # S3 settings (optional)
 S3_ENABLED="true"
 S3_BUCKET="my-backup-bucket"
-S3_PREFIX="sync-shuttle-archive"
+S3_PREFIX="bucketcast-archive"
 ```
 
 ## Safety Features
 
-1. **Path Validation**: All paths must be within `~/.sync-shuttle/`
+1. **Path Validation**: All paths must be within `~/.bucketcast/`
 2. **No Deletion**: The tool never deletes files
 3. **No Overwrites**: Existing files are never overwritten without `--force`
 4. **Confirmation Prompts**: Force mode requires explicit confirmation
@@ -215,18 +215,18 @@ S3_PREFIX="sync-shuttle-archive"
 Enable S3 for cloud backup:
 
 ```bash
-# In sync-shuttle.conf
+# In bucketcast.conf
 S3_ENABLED="true"
-S3_BUCKET="my-sync-shuttle-bucket"
+S3_BUCKET="my-bucketcast-bucket"
 S3_PREFIX="archive"
 
 # Use with any sync
-sync-shuttle.sh push -s myserver -S ~/data/ --s3-archive
+bucketcast.sh push -s myserver -S ~/data/ --s3-archive
 
 # Or use S3 as intermediate layer
-sync-shuttle.sh s3-push -s myserver -S ~/data/
+bucketcast.sh s3-push -s myserver -S ~/data/
 # On another machine:
-sync-shuttle.sh s3-pull --transfer-id <uuid>
+bucketcast.sh s3-pull --transfer-id <uuid>
 ```
 
 ## TUI (Terminal User Interface)
@@ -234,7 +234,7 @@ sync-shuttle.sh s3-pull --transfer-id <uuid>
 Launch the interactive interface:
 
 ```bash
-sync-shuttle tui
+bucketcast tui
 ```
 
 The TUI is automatically set up by the installer (isolated Python venv, no global packages).
@@ -251,7 +251,7 @@ The TUI provides:
 
 ```
 [2024-01-15 10:30:45] [INFO] Starting PUSH operation [abc123-...]
-[2024-01-15 10:30:46] [INFO] Transferring: ~/file.txt -> ~/.sync-shuttle/remote/myserver/files/
+[2024-01-15 10:30:46] [INFO] Transferring: ~/file.txt -> ~/.bucketcast/remote/myserver/files/
 [2024-01-15 10:30:50] [SUCCESS] Push operation completed
 ```
 
@@ -265,10 +265,10 @@ The TUI provides:
 
 ```bash
 # Recent operations
-tail -f ~/.sync-shuttle/logs/sync.log
+tail -f ~/.bucketcast/logs/sync.log
 
 # Parse JSON logs (requires jq)
-cat ~/.sync-shuttle/logs/sync.jsonl | jq 'select(.status=="FAILED")'
+cat ~/.bucketcast/logs/sync.jsonl | jq 'select(.status=="FAILED")'
 ```
 
 ## Exit Codes
@@ -301,17 +301,17 @@ ssh-copy-id -p 22 user@host
 
 ```bash
 # Check directory permissions
-ls -la ~/.sync-shuttle/
+ls -la ~/.bucketcast/
 
 # Fix if needed
-chmod -R u+rwX ~/.sync-shuttle/
+chmod -R u+rwX ~/.bucketcast/
 ```
 
 ### Rsync Errors
 
 ```bash
 # Run with verbose
-sync-shuttle.sh push -s myserver -S ~/file.txt --verbose
+bucketcast.sh push -s myserver -S ~/file.txt --verbose
 
 # Common fixes:
 # - Ensure rsync is installed on remote

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -37,7 +37,7 @@ safety over convenience, ensuring files are never accidentally deleted or overwr
 ### 2. Sandboxed Operations
 - All files stored in `~/.sync-shuttle/`
 - Structure: `~/.sync-shuttle/remote/<server_id>/files/`
-- Local staging: `~/.sync-shuttle/local/outbox/`
+- Local shares: `~/.sync-shuttle/local/outbox/` (global/ or <server_id>/)
 - Incoming files: `~/.sync-shuttle/local/inbox/`
 
 ### 3. Comprehensive Logging
@@ -79,7 +79,10 @@ safety over convenience, ensuring files are never accidentally deleted or overwr
 │       └── files/             # Files synced from this server
 ├── local/
 │   ├── inbox/                 # Files received from remotes
-│   └── outbox/                # Files staged for sending
+│   │   └── <server_id>/       # Per-server incoming files
+│   └── outbox/                # Files shared with remotes
+│       ├── global/            # Available to all servers
+│       └── <server_id>/       # Server-specific shares
 ├── logs/
 │   ├── sync.log               # Human-readable log
 │   └── sync.jsonl             # Machine-readable log (JSON Lines)
@@ -167,7 +170,7 @@ LogEntry {
 1. List configured servers → Read `servers.toml`
 2. View sync history → Read `logs/sync.jsonl`
 3. Browse remote files → List `remote/<server_id>/files/`
-4. Check pending outbox → List `local/outbox/`
+4. Check shared files → List `local/outbox/global/` or `local/outbox/<server_id>/`
 
 ### Write Patterns
 1. Add server → Append to `servers.toml`

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1,15 +1,15 @@
-# Sync Shuttle - Project Specification
+# Bucketcast - Project Specification
 
 ## Project Intent
 
-Sync Shuttle is a **safe, idempotent file synchronization tool** designed for manual, 
+Bucketcast is a **safe, idempotent file synchronization tool** designed for manual, 
 on-demand file transfers between a home computer and remote servers. It prioritizes 
 safety over convenience, ensuring files are never accidentally deleted or overwritten.
 
 ## Key Assumptions
 
 1. **Manual Execution**: This is NOT a real-time sync daemon; it runs on-demand
-2. **Known Paths Only**: All operations are sandboxed to `~/.sync-shuttle/` directory
+2. **Known Paths Only**: All operations are sandboxed to `~/.bucketcast/` directory
 3. **SSH-Based**: Remote transfers use scp/rsync over SSH (keys recommended)
 4. **Single User**: Designed for personal use, not multi-tenant environments
 5. **Idempotent**: Running the same sync twice produces the same result safely
@@ -35,10 +35,10 @@ safety over convenience, ensuring files are never accidentally deleted or overwr
 - No overwrites without `--force` flag
 
 ### 2. Sandboxed Operations
-- All files stored in `~/.sync-shuttle/`
-- Structure: `~/.sync-shuttle/remote/<server_id>/files/`
-- Local shares: `~/.sync-shuttle/local/outbox/` (global/ or <server_id>/)
-- Incoming files: `~/.sync-shuttle/local/inbox/`
+- All files stored in `~/.bucketcast/`
+- Structure: `~/.bucketcast/remote/<server_id>/files/`
+- Local shares: `~/.bucketcast/local/outbox/` (global/ or <server_id>/)
+- Incoming files: `~/.bucketcast/local/inbox/`
 
 ### 3. Comprehensive Logging
 - UUID per operation
@@ -70,9 +70,9 @@ safety over convenience, ensuring files are never accidentally deleted or overwr
 ## Directory Structure (Runtime)
 
 ```
-~/.sync-shuttle/
+~/.bucketcast/
 ├── config/
-│   ├── sync-shuttle.conf      # Main configuration
+│   ├── bucketcast.conf      # Main configuration
 │   └── servers.toml           # Server definitions
 ├── remote/
 │   └── <server_id>/
@@ -102,7 +102,7 @@ ServerConfig {
     port: integer (1-65535, default: 22)
     user: string (SSH username)
     identity_file: string (path to SSH key, optional)
-    remote_base: string (remote sync-shuttle path)
+    remote_base: string (remote bucketcast path)
     enabled: boolean
     s3_backup: boolean (optional)
 }
@@ -180,7 +180,7 @@ LogEntry {
 
 ## Safety Mechanisms
 
-1. **Path Validation**: All paths must be within `~/.sync-shuttle/`
+1. **Path Validation**: All paths must be within `~/.bucketcast/`
 2. **No Deletion**: Tool never deletes files (archive only)
 3. **Collision Detection**: Check for existing files before write
 4. **Dry Run Default**: Recommend dry-run for first use

--- a/_other/AUDIT_REPORT.md
+++ b/_other/AUDIT_REPORT.md
@@ -1,4 +1,4 @@
-# Sync Shuttle - Comprehensive Project Audit
+# Bucketcast - Comprehensive Project Audit
 
 **Audit Date:** 2026-01-01  
 **Auditor:** Claude  
@@ -8,7 +8,7 @@
 
 ## Executive Summary
 
-The Sync Shuttle project is **substantially complete** and meets the core requirements specified in the original request. The implementation follows the stated design principles (safety-first, idempotent, sandboxed operations) and includes comprehensive documentation.
+The Bucketcast project is **substantially complete** and meets the core requirements specified in the original request. The implementation follows the stated design principles (safety-first, idempotent, sandboxed operations) and includes comprehensive documentation.
 
 | Category | Status | Score |
 |----------|--------|-------|
@@ -60,7 +60,7 @@ The Sync Shuttle project is **substantially complete** and meets the core requir
 
 ---
 
-### 3. sync-shuttle.sh ✅ PASS
+### 3. bucketcast.sh ✅ PASS
 **Lines:** 1,139 | **Purpose:** Main executable
 
 | Requirement | Status | Notes |
@@ -174,7 +174,7 @@ The Sync Shuttle project is **substantially complete** and meets the core requir
 
 ---
 
-### 9. tui/sync_tui.py ✅ PASS
+### 9. tui/bucketcast_tui.py ✅ PASS
 **Lines:** 666 | **Purpose:** Interactive terminal interface
 
 | Component | Status | Notes |
@@ -207,7 +207,7 @@ rich>=13.0.0
 
 ---
 
-### 11. config/sync-shuttle.conf.example ✅ PASS
+### 11. config/bucketcast.conf.example ✅ PASS
 **Lines:** 111 | **Purpose:** Main configuration template
 
 | Setting Category | Status | Notes |
@@ -242,17 +242,17 @@ rich>=13.0.0
 
 | Requirement | Status | Implementation |
 |-------------|--------|----------------|
-| Safe, idempotent sh script | ✅ | sync-shuttle.sh with safety checks |
+| Safe, idempotent sh script | ✅ | bucketcast.sh with safety checks |
 | Well documented with annotation block | ✅ | 310-line header documentation |
 | Variables at start + .config | ✅ | Lines 326-361 + config files |
 | No rm -rf | ✅ | No delete commands found |
 | No overwriting existing files | ✅ | --ignore-existing, collision detection |
-| Specific dir only (~/.sync-shuttle) | ✅ | validate_path_within_sandbox() |
+| Specific dir only (~/.bucketcast) | ✅ | validate_path_within_sandbox() |
 | Two-way sync (push/pull) | ✅ | action_push(), action_pull() |
-| Server-specific paths | ✅ | ~/.sync-shuttle/remote/<server_id>/files/ |
+| Server-specific paths | ✅ | ~/.bucketcast/remote/<server_id>/files/ |
 | Log record (datetime, paths, uuid) | ✅ | log_operation() with all fields |
 | CLI with --dry-run, --force | ✅ | All flags implemented |
-| Optional TUI | ✅ | tui/sync_tui.py with Textual |
+| Optional TUI | ✅ | tui/bucketcast_tui.py with Textual |
 | Optional S3 features | ✅ | lib/s3.sh with archive/intermediate |
 | Schema contracts | ✅ | 4 schemas in SPECIFICATION.md |
 | Idempotent systems | ✅ | Safe to run multiple times |
@@ -300,13 +300,13 @@ None identified.
 
 | File | Lines | Size | Purpose |
 |------|-------|------|---------|
-| sync-shuttle.sh | 1,139 | ~42KB | Main executable |
+| bucketcast.sh | 1,139 | ~42KB | Main executable |
 | lib/s3.sh | 469 | ~14KB | S3 integration |
 | lib/validation.sh | 386 | ~13KB | Security validation |
 | lib/transfer.sh | 368 | ~12KB | File transfers |
 | lib/core.sh | 366 | ~12KB | Core utilities |
 | lib/logging.sh | 228 | ~8.5KB | Logging |
-| tui/sync_tui.py | 666 | ~21KB | Python TUI |
+| tui/bucketcast_tui.py | 666 | ~21KB | Python TUI |
 | SPECIFICATION.md | 207 | ~6.5KB | Project spec |
 | README.md | ~250 | ~7.5KB | Documentation |
 | config/*.example | ~200 | ~7.5KB | Config templates |
@@ -317,9 +317,9 @@ None identified.
 ## Recommendations
 
 ### Immediate (Before First Use)
-1. ✅ Make sync-shuttle.sh executable: `chmod +x sync-shuttle.sh`
-2. ✅ Run `./sync-shuttle.sh init` to create directory structure
-3. Configure at least one server in `~/.sync-shuttle/config/servers.conf`
+1. ✅ Make bucketcast.sh executable: `chmod +x bucketcast.sh`
+2. ✅ Run `./bucketcast.sh init` to create directory structure
+3. Configure at least one server in `~/.bucketcast/config/servers.conf`
 
 ### Short-term
 1. Add a basic test script in tests/
@@ -335,7 +335,7 @@ None identified.
 
 ## Conclusion
 
-The Sync Shuttle project is **production-ready for its core use case** of safe, manual file synchronization. All critical safety features are implemented, documentation is comprehensive, and the code follows best practices for shell scripting.
+The Bucketcast project is **production-ready for its core use case** of safe, manual file synchronization. All critical safety features are implemented, documentation is comprehensive, and the code follows best practices for shell scripting.
 
 The main gaps are in testing infrastructure and installation automation, which are important for maintainability but do not affect the tool's functionality or safety.
 

--- a/_other/llm-v1.0.txt
+++ b/_other/llm-v1.0.txt
@@ -1,4 +1,4 @@
-# SYNC-SHUTTLE LLM.TXT
+# BUCKETCAST LLM.TXT
 # Version: 1.0.0
 # Purpose: Complete repository context for AI agents and LLM systems
 # Format: Line-oriented, grepable, information-dense prose
@@ -105,7 +105,7 @@ GREP_SECTIONS :: grep "^\[" llm.txt | grep -v "TOC_LINE"
 [PROJECT_IDENTITY]
 ================================================================================
 
-PROJECT_NAME :: sync-shuttle
+PROJECT_NAME :: bucketcast
 PROJECT_TYPE :: CLI file synchronization tool
 PROJECT_LANGUAGE :: Bash 4.0+ with Python 3.8+ TUI
 PROJECT_LICENSE :: MIT
@@ -144,22 +144,22 @@ ARCH_PRINCIPLE :: Side effects isolated to main script and transfer operations
 ARCH_PRINCIPLE :: Fail-fast with descriptive error messages
 ARCH_PRINCIPLE :: Defense in depth for security
 
-FLOW :: User invokes sync-shuttle.sh
-FLOW :: sync-shuttle.sh -> sources lib/*.sh libraries
-FLOW :: sync-shuttle.sh -> parses CLI arguments
-FLOW :: sync-shuttle.sh -> validates environment
-FLOW :: sync-shuttle.sh -> loads configuration
-FLOW :: sync-shuttle.sh -> executes requested action
+FLOW :: User invokes bucketcast.sh
+FLOW :: bucketcast.sh -> sources lib/*.sh libraries
+FLOW :: bucketcast.sh -> parses CLI arguments
+FLOW :: bucketcast.sh -> validates environment
+FLOW :: bucketcast.sh -> loads configuration
+FLOW :: bucketcast.sh -> executes requested action
 FLOW :: Action -> validation -> preflight -> transfer -> logging
 FLOW :: Exit with appropriate code
 
-LAYER :: CLI Layer (sync-shuttle.sh) - argument parsing; user interaction; orchestration
+LAYER :: CLI Layer (bucketcast.sh) - argument parsing; user interaction; orchestration
 LAYER :: Library Layer (lib/*.sh) - pure functions; reusable logic; no direct I/O
 LAYER :: Config Layer (config/) - user settings; server definitions
-LAYER :: Data Layer (~/.sync-shuttle/) - runtime directories; logs; archives
+LAYER :: Data Layer (~/.bucketcast/) - runtime directories; logs; archives
 LAYER :: TUI Layer (tui/) - optional Python interface; async operations
 
-RUNTIME_DIR :: ~/.sync-shuttle/
+RUNTIME_DIR :: ~/.bucketcast/
 RUNTIME_DIR >> config/ - user configuration files
 RUNTIME_DIR >> remote/<server_id>/files/ - synced files organized by server
 RUNTIME_DIR >> local/inbox/ - files received from remote servers
@@ -172,8 +172,8 @@ RUNTIME_DIR >> tmp/ - temporary staging; lock files
 [FILE_MANIFEST]
 ================================================================================
 
-FILE :: sync-shuttle.sh
-FILE_PATH :: ./sync-shuttle.sh
+FILE :: bucketcast.sh
+FILE_PATH :: ./bucketcast.sh
 FILE_LINES :: 1139
 FILE_PURPOSE :: Main executable script; CLI interface; orchestration
 FILE_CONTAINS :: 310-line man-style documentation header
@@ -240,8 +240,8 @@ FILE_CONTAINS :: list_s3_archives() - enumerate S3 archives
 FILE_CONTAINS :: cleanup_s3_archives() - retention policy enforcement
 FILE_REQUIRES :: aws CLI configured with credentials
 
-FILE :: tui/sync_tui.py
-FILE_PATH :: ./tui/sync_tui.py
+FILE :: tui/bucketcast_tui.py
+FILE_PATH :: ./tui/bucketcast_tui.py
 FILE_LINES :: 666
 FILE_PURPOSE :: Terminal user interface; visual operation management
 FILE_CONTAINS :: ServerConfig dataclass
@@ -257,8 +257,8 @@ FILE_PURPOSE :: Python dependencies for TUI
 FILE_CONTAINS :: textual>=0.40.0
 FILE_CONTAINS :: rich>=13.0.0
 
-FILE :: config/sync-shuttle.conf.example
-FILE_PATH :: ./config/sync-shuttle.conf.example
+FILE :: config/bucketcast.conf.example
+FILE_PATH :: ./config/bucketcast.conf.example
 FILE_LINES :: 111
 FILE_PURPOSE :: Main configuration template
 FILE_CONTAINS :: Base path settings
@@ -277,8 +277,8 @@ FILE_CONTAINS :: Bash associative array syntax for servers
 FILE_CONTAINS :: Example servers (dev; nas; prod; pi; aws)
 FILE_CONTAINS :: identity_file support for SSH keys (.pem)
 
-FILE :: config/.syncshuttlerc.example
-FILE_PATH :: ./config/.syncshuttlerc.example
+FILE :: config/.bucketcastrc.example
+FILE_PATH :: ./config/.bucketcastrc.example
 FILE_PURPOSE :: User-level defaults template
 FILE_CONTAINS :: SSH default identity file
 FILE_CONTAINS :: Default behavior flags
@@ -289,8 +289,8 @@ FILE_PATH :: ./install.sh
 FILE_LINES :: 225
 FILE_PURPOSE :: Curl-able installer script
 FILE_USAGE :: curl -fsSL URL/install.sh | bash
-FILE_CREATES :: ~/.local/share/sync-shuttle/ (installation)
-FILE_CREATES :: ~/.local/bin/sync-shuttle (wrapper)
+FILE_CREATES :: ~/.local/share/bucketcast/ (installation)
+FILE_CREATES :: ~/.local/bin/bucketcast (wrapper)
 FILE_MODIFIES :: ~/.bashrc or ~/.zshrc (PATH addition)
 
 FILE :: README.md
@@ -477,14 +477,14 @@ FUNC_PURE :: no (removes file)
 [CLI_REFERENCE]
 ================================================================================
 
-CMD :: sync-shuttle init
-CMD_PURPOSE :: Initialize sync-shuttle directory structure
-CMD_CREATES :: ~/.sync-shuttle/ and all subdirectories
+CMD :: bucketcast init
+CMD_PURPOSE :: Initialize bucketcast directory structure
+CMD_CREATES :: ~/.bucketcast/ and all subdirectories
 CMD_CREATES :: Default configuration files from examples
 CMD_IDEMPOTENT :: yes - safe to run multiple times
 CMD_EXIT :: 0 on success; 1 on failure
 
-CMD :: sync-shuttle push --server <id> --source <path> (--dry-run) (--force) (--verbose) (--quiet) (--s3-archive)
+CMD :: bucketcast push --server <id> --source <path> (--dry-run) (--force) (--verbose) (--quiet) (--s3-archive)
 CMD_PURPOSE :: Push files from local to remote server
 CMD_REQUIRED :: --server <id> - target server from servers.conf
 CMD_REQUIRED :: --source <path> - local file or directory
@@ -496,40 +496,40 @@ CMD_OPTIONAL :: --s3-archive - archive to S3 after transfer
 CMD_FLOW :: validate -> preflight -> stage locally -> rsync to remote -> log
 CMD_EXIT :: 0 success; 1 general error; 2 invalid args; 3 not initialized; 4 server not found; 5 transfer failed; 6 collision; 7 validation failed; 8 dependency missing
 
-CMD :: sync-shuttle pull --server <id> (--dry-run) (--force) (--verbose) (--quiet) (--s3-archive)
+CMD :: bucketcast pull --server <id> (--dry-run) (--force) (--verbose) (--quiet) (--s3-archive)
 CMD_PURPOSE :: Pull files from remote server to local
 CMD_REQUIRED :: --server <id> - source server from servers.conf
 CMD_OPTIONAL :: Same as push
 CMD_FLOW :: validate -> preflight -> rsync from remote -> stage locally -> log
 CMD_EXIT :: Same as push
 
-CMD :: sync-shuttle list servers
+CMD :: bucketcast list servers
 CMD_PURPOSE :: Display all configured servers
 CMD_OUTPUT :: Table of server id; name; host; enabled status
 CMD_EXIT :: 0 success; 1 no servers configured
 
-CMD :: sync-shuttle list files --server <id>
+CMD :: bucketcast list files --server <id>
 CMD_PURPOSE :: Display synced files for a server
 CMD_OUTPUT :: Tree view of SYNC_BASE_DIR/remote/server_id/files/
 CMD_EXIT :: 0 success; 1 error
 
-CMD :: sync-shuttle status
-CMD_PURPOSE :: Display overall sync-shuttle status
+CMD :: bucketcast status
+CMD_PURPOSE :: Display overall bucketcast status
 CMD_OUTPUT :: Directory sizes; last operations; server count
 CMD_EXIT :: 0 always
 
-CMD :: sync-shuttle tui
+CMD :: bucketcast tui
 CMD_PURPOSE :: Launch terminal user interface
 CMD_REQUIRES :: Python 3.8+; textual; rich
 CMD_EXIT :: 0 on clean exit; 1 on error
 
-CMD :: sync-shuttle --help
+CMD :: bucketcast --help
 CMD_PURPOSE :: Display comprehensive help
 CMD_OUTPUT :: Man-style documentation from header
 
-CMD :: sync-shuttle --version
+CMD :: bucketcast --version
 CMD_PURPOSE :: Display version information
-CMD_OUTPUT :: sync-shuttle version X.Y.Z
+CMD_OUTPUT :: bucketcast version X.Y.Z
 
 ================================================================================
 [SCHEMA_DEFINITIONS]
@@ -544,7 +544,7 @@ SCHEMA_FIELD :: host (string) - hostname or IP address
 SCHEMA_FIELD :: port (integer) - SSH port; default 22
 SCHEMA_FIELD :: user (string) - SSH username
 SCHEMA_FIELD :: identity_file (string) - path to SSH key; optional; supports ~ expansion
-SCHEMA_FIELD :: remote_base (string) - remote sync-shuttle directory path
+SCHEMA_FIELD :: remote_base (string) - remote bucketcast directory path
 SCHEMA_FIELD :: enabled (boolean) - true/false
 SCHEMA_FIELD :: s3_backup (boolean) - archive to S3 after sync; true/false
 SCHEMA_SYNTAX :: declare -A server_<id>=([name]="..." [host]="..." [port]="..." [user]="..." [identity_file]="..." [remote_base]="..." [enabled]="..." [s3_backup]="...")
@@ -593,8 +593,8 @@ SCHEMA_FIELD :: user (string) - executing user
 ================================================================================
 
 CONFIG :: SYNC_BASE_DIR
-CONFIG_DEFAULT :: ~/.sync-shuttle
-CONFIG_PURPOSE :: Root directory for all sync-shuttle data
+CONFIG_DEFAULT :: ~/.bucketcast
+CONFIG_PURPOSE :: Root directory for all bucketcast data
 CONFIG_CONTAINS :: config/; remote/; local/; logs/; archive/; tmp/
 
 CONFIG :: LOG_LEVEL
@@ -646,7 +646,7 @@ EXIT :: 2
 EXIT_MEANING :: Invalid arguments - missing required flags; invalid values
 
 EXIT :: 3
-EXIT_MEANING :: Not initialized - run sync-shuttle init first
+EXIT_MEANING :: Not initialized - run bucketcast init first
 
 EXIT :: 4
 EXIT_MEANING :: Server not found - server_id not in servers.conf or disabled
@@ -668,7 +668,7 @@ EXIT_MEANING :: Dependency missing - required tool not found; bash version too o
 ================================================================================
 
 FLOW :: PUSH OPERATION
-FLOW_STEP :: 1 - User invokes: sync-shuttle push --server <id> --source <path>
+FLOW_STEP :: 1 - User invokes: bucketcast push --server <id> --source <path>
 FLOW_STEP :: 2 - Parse arguments; set global flags (DRY_RUN; FORCE; VERBOSE)
 FLOW_STEP :: 3 - validate_environment() - check bash; tools; directories
 FLOW_STEP :: 4 - validate_server_id(id) - format check
@@ -685,7 +685,7 @@ FLOW_STEP :: 14 - release_lock(push) - free lock
 FLOW_STEP :: 15 - Exit with appropriate code
 
 FLOW :: PULL OPERATION
-FLOW_STEP :: 1 - User invokes: sync-shuttle pull --server <id>
+FLOW_STEP :: 1 - User invokes: bucketcast pull --server <id>
 FLOW_STEP :: 2-8 - Same validation as push
 FLOW_STEP :: 9 - generate_uuid() - create operation identifier
 FLOW_STEP :: 10 - sync_from_remote() - rsync over SSH from server
@@ -694,7 +694,7 @@ FLOW_STEP :: 12 - (if s3_archive) archive_to_s3() - upload to S3
 FLOW_STEP :: 13-15 - Same logging and cleanup as push
 
 FLOW :: INIT OPERATION
-FLOW_STEP :: 1 - User invokes: sync-shuttle init
+FLOW_STEP :: 1 - User invokes: bucketcast init
 FLOW_STEP :: 2 - Create SYNC_BASE_DIR if not exists
 FLOW_STEP :: 3 - Create subdirectories: config/; remote/; local/inbox/; local/outbox/; logs/; archive/; tmp/
 FLOW_STEP :: 4 - Copy example configs if not exist
@@ -814,7 +814,7 @@ DEPEND_CHECK :: check_s3_available()
 DEPEND :: python3 >= 3.8
 DEPEND_TYPE :: Optional
 DEPEND_PURPOSE :: TUI interface
-DEPEND_CHECK :: sync-shuttle tui command
+DEPEND_CHECK :: bucketcast tui command
 
 DEPEND :: textual >= 0.40.0
 DEPEND_TYPE :: Optional (Python)
@@ -956,13 +956,13 @@ PATTERN_RESULT :: Optional SSH key with tilde expansion
 [TROUBLESHOOTING]
 ================================================================================
 
-TROUBLE :: "Sync Shuttle not initialized"
-TROUBLE_CAUSE :: SYNC_BASE_DIR (~/.sync-shuttle/) does not exist
-TROUBLE_FIX :: Run: sync-shuttle init
+TROUBLE :: "Bucketcast not initialized"
+TROUBLE_CAUSE :: SYNC_BASE_DIR (~/.bucketcast/) does not exist
+TROUBLE_FIX :: Run: bucketcast init
 
 TROUBLE :: "Server not found: <id>"
 TROUBLE_CAUSE :: Server ID not in servers.conf or server disabled
-TROUBLE_FIX :: Check ~/.sync-shuttle/config/servers.conf; ensure enabled="true"
+TROUBLE_FIX :: Check ~/.bucketcast/config/servers.conf; ensure enabled="true"
 
 TROUBLE :: "Missing required tools: rsync"
 TROUBLE_CAUSE :: rsync not installed
@@ -973,7 +973,7 @@ TROUBLE_CAUSE :: Old bash version (common on macOS)
 TROUBLE_FIX :: Install newer bash: brew install bash; update PATH
 
 TROUBLE :: "Security violation: Path is outside sandbox"
-TROUBLE_CAUSE :: Attempted operation on path outside ~/.sync-shuttle/
+TROUBLE_CAUSE :: Attempted operation on path outside ~/.bucketcast/
 TROUBLE_FIX :: Only operate on files within SYNC_BASE_DIR
 
 TROUBLE :: "SSH connection failed"
@@ -1001,7 +1001,7 @@ This section answers questions AI agents commonly ask about this codebase.
 Designed to reduce follow-up queries and provide immediate answers.
 
 FAQ :: What is this project?
-FAQ_ANSWER :: sync-shuttle is a CLI file synchronization tool that prioritizes safety over convenience
+FAQ_ANSWER :: bucketcast is a CLI file synchronization tool that prioritizes safety over convenience
 FAQ_ANSWER :: It wraps rsync with guardrails to prevent accidental data loss
 FAQ_ANSWER :: Core guarantee: never deletes files; never overwrites without consent
 
@@ -1012,33 +1012,33 @@ FAQ_ANSWER :: No compiled components; pure scripts
 
 FAQ :: How do I install this?
 FAQ_ANSWER :: Option 1: curl -fsSL URL/install.sh | bash
-FAQ_ANSWER :: Option 2: git clone; chmod +x sync-shuttle.sh; ./sync-shuttle.sh init
+FAQ_ANSWER :: Option 2: git clone; chmod +x bucketcast.sh; ./bucketcast.sh init
 FAQ_ANSWER :: Option 3: Copy files manually; run init
 
 FAQ :: How do I add a new server?
-FAQ_ANSWER :: Edit ~/.sync-shuttle/config/servers.conf
+FAQ_ANSWER :: Edit ~/.bucketcast/config/servers.conf
 FAQ_ANSWER :: Add new declare -A server_<id>=(...) block
 FAQ_ANSWER :: Required fields: host; user; remote_base; enabled="true"
 FAQ_ANSWER :: Optional: port (default 22); identity_file; s3_backup
 
 FAQ :: How do I push files to a server?
-FAQ_ANSWER :: sync-shuttle push --server <id> --source <path>
-FAQ_ANSWER :: Always test first: sync-shuttle push --server <id> --source <path> --dry-run
+FAQ_ANSWER :: bucketcast push --server <id> --source <path>
+FAQ_ANSWER :: Always test first: bucketcast push --server <id> --source <path> --dry-run
 FAQ_ANSWER :: Files go to: remote_server:remote_base/local/inbox/your_hostname/
 
 FAQ :: How do I pull files from a server?
-FAQ_ANSWER :: sync-shuttle pull --server <id>
-FAQ_ANSWER :: Files arrive at: ~/.sync-shuttle/local/inbox/<server_id>/
+FAQ_ANSWER :: bucketcast pull --server <id>
+FAQ_ANSWER :: Files arrive at: ~/.bucketcast/local/inbox/<server_id>/
 
 FAQ :: Where are synced files stored?
-FAQ_ANSWER :: Push: Local staging at ~/.sync-shuttle/remote/<server_id>/files/
+FAQ_ANSWER :: Push: Local staging at ~/.bucketcast/remote/<server_id>/files/
 FAQ_ANSWER :: Push: Remote destination at <remote_base>/local/inbox/<hostname>/
-FAQ_ANSWER :: Pull: Local destination at ~/.sync-shuttle/local/inbox/<server_id>/
+FAQ_ANSWER :: Pull: Local destination at ~/.bucketcast/local/inbox/<server_id>/
 
 FAQ :: Where are logs stored?
-FAQ_ANSWER :: Human-readable: ~/.sync-shuttle/logs/sync.log
-FAQ_ANSWER :: Machine-readable: ~/.sync-shuttle/logs/sync.jsonl (JSON Lines)
-FAQ_ANSWER :: Query JSON: jq '.status' ~/.sync-shuttle/logs/sync.jsonl
+FAQ_ANSWER :: Human-readable: ~/.bucketcast/logs/sync.log
+FAQ_ANSWER :: Machine-readable: ~/.bucketcast/logs/sync.jsonl (JSON Lines)
+FAQ_ANSWER :: Query JSON: jq '.status' ~/.bucketcast/logs/sync.jsonl
 
 FAQ :: What does --dry-run do?
 FAQ_ANSWER :: Simulates the operation without making changes
@@ -1049,7 +1049,7 @@ FAQ_ANSWER :: No files are modified; no network transfer occurs
 FAQ :: What does --force do?
 FAQ_ANSWER :: Allows overwriting existing files at destination
 FAQ_ANSWER :: Original files are archived before overwrite
-FAQ_ANSWER :: Archive location: ~/.sync-shuttle/archive/<server_id>/<timestamp>/
+FAQ_ANSWER :: Archive location: ~/.bucketcast/archive/<server_id>/<timestamp>/
 FAQ_ANSWER :: Without --force: operation fails with exit code 6 on collision
 
 FAQ :: How do I use SSH keys (.pem files)?
@@ -1066,7 +1066,7 @@ FAQ_ANSWER :: Password prompts will appear if key auth fails
 FAQ :: Can this delete files on the remote?
 FAQ_ANSWER :: NO - this is a core safety guarantee
 FAQ_ANSWER :: rsync is NEVER invoked with --delete
-FAQ_ANSWER :: To delete remote files; use ssh directly (not sync-shuttle)
+FAQ_ANSWER :: To delete remote files; use ssh directly (not bucketcast)
 
 FAQ :: Can this overwrite files?
 FAQ_ANSWER :: Only with explicit --force flag
@@ -1079,13 +1079,13 @@ FAQ_ANSWER :: Re-running the command resumes transfer
 FAQ_ANSWER :: No corruption; rsync handles this gracefully
 
 FAQ :: How do I see what servers are configured?
-FAQ_ANSWER :: sync-shuttle list servers
-FAQ_ANSWER :: Or: cat ~/.sync-shuttle/config/servers.conf
+FAQ_ANSWER :: bucketcast list servers
+FAQ_ANSWER :: Or: cat ~/.bucketcast/config/servers.conf
 
-FAQ :: How do I check if sync-shuttle is working?
-FAQ_ANSWER :: sync-shuttle status - shows overview
-FAQ_ANSWER :: sync-shuttle --version - shows version
-FAQ_ANSWER :: sync-shuttle list servers - shows configured servers
+FAQ :: How do I check if bucketcast is working?
+FAQ_ANSWER :: bucketcast status - shows overview
+FAQ_ANSWER :: bucketcast --version - shows version
+FAQ_ANSWER :: bucketcast list servers - shows configured servers
 
 FAQ :: What are the exit codes?
 FAQ_ANSWER :: 0=success; 1=general error; 2=invalid args; 3=not initialized
@@ -1100,13 +1100,13 @@ FAQ_ANSWER :: ./tests/run_tests.sh integration - integration tests only
 FAQ_ANSWER :: ./tests/run_tests.sh e2e - end-to-end tests only
 
 FAQ :: Where is the main entry point?
-FAQ_ANSWER :: sync-shuttle.sh is the main executable
+FAQ_ANSWER :: bucketcast.sh is the main executable
 FAQ_ANSWER :: Line ~400: Library sourcing begins
 FAQ_ANSWER :: Line ~500: Argument parsing begins
 FAQ_ANSWER :: Line ~700: Action dispatch begins
 
 FAQ :: How do I add a new command/action?
-FAQ_ANSWER :: 1. Add case in action dispatch (~line 700 in sync-shuttle.sh)
+FAQ_ANSWER :: 1. Add case in action dispatch (~line 700 in bucketcast.sh)
 FAQ_ANSWER :: 2. Create handler function (do_<action>)
 FAQ_ANSWER :: 3. Add to help text
 FAQ_ANSWER :: 4. Add tests in tests/e2e/
@@ -1148,13 +1148,13 @@ FAQ_ANSWER :: NEVER: --delete (core safety guarantee)
 
 FAQ :: How do I configure S3 archival?
 FAQ_ANSWER :: 1. Install and configure aws CLI
-FAQ_ANSWER :: 2. Set S3_BUCKET in sync-shuttle.conf
+FAQ_ANSWER :: 2. Set S3_BUCKET in bucketcast.conf
 FAQ_ANSWER :: 3. Use --s3-archive flag on push/pull
 FAQ_ANSWER :: Files archived to: s3://bucket/archive/server_id/date/uuid/
 
 FAQ :: What is the TUI?
 FAQ_ANSWER :: Terminal User Interface - visual file browser
-FAQ_ANSWER :: Launch: sync-shuttle tui
+FAQ_ANSWER :: Launch: bucketcast tui
 FAQ_ANSWER :: Requires: pip3 install textual rich
 FAQ_ANSWER :: Keys: q=quit; p=push; l=pull; r=refresh
 
@@ -1165,11 +1165,11 @@ FAQ_ANSWER :: Follow existing code style
 FAQ_ANSWER :: Update llm.txt if adding features
 
 FAQ :: Where is the config file schema?
-FAQ_ANSWER :: sync-shuttle.conf: see config/sync-shuttle.conf.example
+FAQ_ANSWER :: bucketcast.conf: see config/bucketcast.conf.example
 FAQ_ANSWER :: servers.conf: see config/servers.conf.example
 FAQ_ANSWER :: Schema definitions: see [SCHEMA_DEFINITIONS] in this file
 
-FAQ :: Why is it called sync-shuttle?
+FAQ :: Why is it called bucketcast?
 FAQ_ANSWER :: Shuttle: moves files back and forth between machines
 FAQ_ANSWER :: Sync: synchronization of file state
 FAQ_ANSWER :: Evokes safe; reliable transportation
@@ -1259,7 +1259,7 @@ EDGE :: Concurrent push to same server
 EDGE_BEHAVIOR :: Second operation blocked by lock
 EDGE_LOGGED :: Yes; "already running" error
 EDGE_EXIT :: 1 (general error)
-EDGE_LOCK :: ~/.sync-shuttle/tmp/push.lock
+EDGE_LOCK :: ~/.bucketcast/tmp/push.lock
 
 EDGE :: Running as root
 EDGE_BEHAVIOR :: Works but not recommended
@@ -1370,7 +1370,7 @@ TODO_ITEM :: AI Agent API - Secure file access for LLMs
 This section guides AI agents on how to modify this codebase safely.
 
 MOD :: Adding a new CLI flag
-MOD_STEP :: 1. Edit sync-shuttle.sh argument parsing (~line 500)
+MOD_STEP :: 1. Edit bucketcast.sh argument parsing (~line 500)
 MOD_STEP :: 2. Add case in while loop: --newflag) NEWFLAG="true"; shift ;;
 MOD_STEP :: 3. Initialize variable at top: NEWFLAG="${NEWFLAG:-false}"
 MOD_STEP :: 4. Add to help text (~line 430)
@@ -1378,7 +1378,7 @@ MOD_STEP :: 5. Document in llm.txt [CLI_REFERENCE]
 MOD_STEP :: 6. Add test in tests/e2e/test_scenarios.sh
 
 MOD :: Adding a new action (subcommand)
-MOD_STEP :: 1. Add case in action dispatch (~line 700 in sync-shuttle.sh)
+MOD_STEP :: 1. Add case in action dispatch (~line 700 in bucketcast.sh)
 MOD_STEP :: 2. Create do_newaction() function
 MOD_STEP :: 3. Add to help text
 MOD_STEP :: 4. Document in llm.txt
@@ -1398,8 +1398,8 @@ MOD_STEP :: 4. Update [SCHEMA_DEFINITIONS] in llm.txt
 MOD_STEP :: 5. Add validation if needed
 
 MOD :: Adding a new config option
-MOD_STEP :: 1. Add to config/sync-shuttle.conf.example with documentation
-MOD_STEP :: 2. Add default in sync-shuttle.sh variable initialization
+MOD_STEP :: 1. Add to config/bucketcast.conf.example with documentation
+MOD_STEP :: 2. Add default in bucketcast.sh variable initialization
 MOD_STEP :: 3. Document in llm.txt [CONFIGURATION_REFERENCE]
 
 MOD :: Adding a new exit code
@@ -1421,7 +1421,7 @@ MOD_STEP :: 2. Test extensively with --dry-run
 MOD_STEP :: 3. Document changes
 
 MOD :: Adding Python TUI feature
-MOD_STEP :: 1. Edit tui/sync_tui.py
+MOD_STEP :: 1. Edit tui/bucketcast_tui.py
 MOD_STEP :: 2. Follow Textual widget patterns
 MOD_STEP :: 3. Update requirements.txt if new dependency
 
@@ -1438,19 +1438,19 @@ CODING_STYLE :: Fail fast with meaningful errors
 
 This section shows how files depend on and interact with each other.
 
-REL :: sync-shuttle.sh -> lib/*.sh
+REL :: bucketcast.sh -> lib/*.sh
 REL_TYPE :: sources (includes)
 REL_ORDER :: core.sh; logging.sh; validation.sh; transfer.sh; s3.sh
 REL_NOTE :: Order matters; later libs may use earlier functions
 
-REL :: sync-shuttle.sh -> config/sync-shuttle.conf
+REL :: bucketcast.sh -> config/bucketcast.conf
 REL_TYPE :: sources (user config)
-REL_LOCATION :: ~/.sync-shuttle/config/sync-shuttle.conf
+REL_LOCATION :: ~/.bucketcast/config/bucketcast.conf
 REL_OPTIONAL :: Yes; uses defaults if missing
 
 REL :: lib/core.sh -> config/servers.conf
 REL_TYPE :: sources (server definitions)
-REL_LOCATION :: ~/.sync-shuttle/config/servers.conf
+REL_LOCATION :: ~/.bucketcast/config/servers.conf
 REL_REQUIRED :: Yes for push/pull operations
 
 REL :: lib/transfer.sh -> lib/core.sh
@@ -1477,9 +1477,9 @@ REL :: lib/validation.sh -> lib/logging.sh
 REL_TYPE :: calls functions
 REL_FUNCTIONS :: log_error(); log_debug(); log_warn()
 
-REL :: tui/sync_tui.py -> sync-shuttle.sh
+REL :: tui/bucketcast_tui.py -> bucketcast.sh
 REL_TYPE :: subprocess execution
-REL_METHOD :: subprocess.run(["sync-shuttle.sh", ...])
+REL_METHOD :: subprocess.run(["bucketcast.sh", ...])
 
 REL :: tests/*.sh -> lib/*.sh
 REL_TYPE :: sources for testing
@@ -1489,15 +1489,15 @@ REL :: tests/*.sh -> tests/helpers/*.sh
 REL_TYPE :: sources helpers
 REL_PROVIDES :: Assertions; fixtures; mocks
 
-REL :: install.sh -> sync-shuttle.sh
+REL :: install.sh -> bucketcast.sh
 REL_TYPE :: copies and wraps
-REL_CREATES :: ~/.local/bin/sync-shuttle wrapper
+REL_CREATES :: ~/.local/bin/bucketcast wrapper
 
-CALL_HIERARCHY :: User -> sync-shuttle.sh -> lib/validation.sh (validate)
-CALL_HIERARCHY :: User -> sync-shuttle.sh -> lib/core.sh (config)
-CALL_HIERARCHY :: User -> sync-shuttle.sh -> lib/transfer.sh (execute)
-CALL_HIERARCHY :: User -> sync-shuttle.sh -> lib/logging.sh (throughout)
-CALL_HIERARCHY :: User -> sync-shuttle.sh -> lib/s3.sh (optional)
+CALL_HIERARCHY :: User -> bucketcast.sh -> lib/validation.sh (validate)
+CALL_HIERARCHY :: User -> bucketcast.sh -> lib/core.sh (config)
+CALL_HIERARCHY :: User -> bucketcast.sh -> lib/transfer.sh (execute)
+CALL_HIERARCHY :: User -> bucketcast.sh -> lib/logging.sh (throughout)
+CALL_HIERARCHY :: User -> bucketcast.sh -> lib/s3.sh (optional)
 
 DATA_FLOW_PUSH :: User args -> validate -> load server -> stage local -> rsync remote -> log
 DATA_FLOW_PULL :: User args -> validate -> load server -> rsync local -> stage inbox -> log
@@ -1538,34 +1538,34 @@ TERM_DEFINITION :: (Future) Full-text search database of synced files
 ================================================================================
 
 QUICK :: Initialize
-QUICK_CMD :: sync-shuttle init
+QUICK_CMD :: bucketcast init
 
 QUICK :: Push files to server
-QUICK_CMD :: sync-shuttle push --server myserver --source ~/files/ --dry-run
-QUICK_CMD :: sync-shuttle push --server myserver --source ~/files/
+QUICK_CMD :: bucketcast push --server myserver --source ~/files/ --dry-run
+QUICK_CMD :: bucketcast push --server myserver --source ~/files/
 
 QUICK :: Pull files from server
-QUICK_CMD :: sync-shuttle pull --server myserver --dry-run
-QUICK_CMD :: sync-shuttle pull --server myserver
+QUICK_CMD :: bucketcast pull --server myserver --dry-run
+QUICK_CMD :: bucketcast pull --server myserver
 
 QUICK :: List servers
-QUICK_CMD :: sync-shuttle list servers
+QUICK_CMD :: bucketcast list servers
 
 QUICK :: Check status
-QUICK_CMD :: sync-shuttle status
+QUICK_CMD :: bucketcast status
 
 QUICK :: Launch TUI
-QUICK_CMD :: sync-shuttle tui
+QUICK_CMD :: bucketcast tui
 
 QUICK :: Get help
-QUICK_CMD :: sync-shuttle --help
+QUICK_CMD :: bucketcast --help
 
 QUICK :: View logs
-QUICK_CMD :: cat ~/.sync-shuttle/logs/sync.log
-QUICK_CMD :: jq . ~/.sync-shuttle/logs/sync.jsonl
+QUICK_CMD :: cat ~/.bucketcast/logs/sync.log
+QUICK_CMD :: jq . ~/.bucketcast/logs/sync.jsonl
 
 QUICK :: Edit server config
-QUICK_CMD :: nano ~/.sync-shuttle/config/servers.conf
+QUICK_CMD :: nano ~/.bucketcast/config/servers.conf
 
 ================================================================================
 [DOCUMENT_METADATA]

--- a/_other/llm.txt
+++ b/_other/llm.txt
@@ -1,4 +1,4 @@
-# SYNC-SHUTTLE LLM.TXT
+# BUCKETCAST LLM.TXT
 # Version: 1.1.0
 # Purpose: Complete repository context for AI agents and LLM systems
 # Format: Line-oriented, grepable, topic-oriented knowledge blocks
@@ -59,7 +59,7 @@ SECTION_TYPE :: AUTO
 
 TOC_LINE :: 001 - [GREP_MANUAL] - Query patterns for v1.1.0
 TOC_LINE :: 050 - [TABLE_OF_CONTENTS] - This navigation
-TOC_LINE :: 080 - [PROJECT_IDENTITY] - What sync-shuttle is
+TOC_LINE :: 080 - [PROJECT_IDENTITY] - What bucketcast is
 TOC_LINE :: 130 - [ARCHITECTURE_OVERVIEW] - System structure
 TOC_LINE :: 200 - [FILE_MANIFEST] - All files with summaries
 TOC_LINE :: 350 - [FUNCTION_REFERENCE] - Functions with topic blocks
@@ -82,7 +82,7 @@ LINE_COUNT :: ~1950 lines
 ================================================================================
 SECTION_TYPE :: MANUAL
 
-PROJECT_NAME :: sync-shuttle
+PROJECT_NAME :: bucketcast
 PROJECT_TYPE :: CLI file synchronization tool
 PROJECT_LANGUAGE :: Bash 4.0+ with Python 3.8+ TUI
 PROJECT_LICENSE :: MIT
@@ -121,10 +121,10 @@ ARCH_PRINCIPLE :: Fail-fast with descriptive error messages
 ARCH_PRINCIPLE :: Defense in depth for security
 
 TOPIC :: RUNTIME_STRUCTURE
-TOPIC_DESCRIPTION :: Directory layout for sync-shuttle runtime data
-TOPIC_FILES :: ~/.sync-shuttle/*
+TOPIC_DESCRIPTION :: Directory layout for bucketcast runtime data
+TOPIC_FILES :: ~/.bucketcast/*
 
-RUNTIME_DIR :: ~/.sync-shuttle/ | Root for all sync-shuttle data | CREATED_BY:init
+RUNTIME_DIR :: ~/.bucketcast/ | Root for all bucketcast data | CREATED_BY:init
 DETAIL:RUNTIME_DIR :: SUBDIR config/ - user configuration files
 DETAIL:RUNTIME_DIR :: SUBDIR remote/<server_id>/files/ - synced files by server
 DETAIL:RUNTIME_DIR :: SUBDIR local/inbox/ - files received from remote
@@ -133,10 +133,10 @@ DETAIL:RUNTIME_DIR :: SUBDIR logs/ - sync.log (human) and sync.jsonl (machine)
 DETAIL:RUNTIME_DIR :: SUBDIR archive/ - versioned backups before overwrites
 DETAIL:RUNTIME_DIR :: SUBDIR tmp/ - temporary staging and lock files
 
-LAYER :: CLI (sync-shuttle.sh) | Argument parsing; user interaction; orchestration
+LAYER :: CLI (bucketcast.sh) | Argument parsing; user interaction; orchestration
 LAYER :: Library (lib/*.sh) | Pure functions; reusable logic; no direct I/O
 LAYER :: Config (config/) | User settings; server definitions
-LAYER :: Data (~/.sync-shuttle/) | Runtime directories; logs; archives
+LAYER :: Data (~/.bucketcast/) | Runtime directories; logs; archives
 LAYER :: TUI (tui/) | Optional Python interface; async operations
 
 ================================================================================
@@ -146,19 +146,19 @@ SECTION_TYPE :: AUTO
 
 TOPIC :: CORE_EXECUTABLES
 TOPIC_DESCRIPTION :: Main scripts that users invoke directly
-TOPIC_FILES :: sync-shuttle.sh; install.sh
+TOPIC_FILES :: bucketcast.sh; install.sh
 
-FILE :: sync-shuttle.sh | Main CLI executable; orchestrates all operations | LOC:./sync-shuttle.sh:1139 | CONTAINS:argument_parsing,action_dispatch,init,push,pull,list,status | EXPORTS:SYNC_BASE_DIR,CONFIG_DIR,LOGS_DIR
-DETAIL:sync-shuttle.sh :: LINES 1-310 - embedded man-style documentation
-DETAIL:sync-shuttle.sh :: LINES 310-500 - global variables and library sourcing
-DETAIL:sync-shuttle.sh :: LINES 500-700 - argument parsing
-DETAIL:sync-shuttle.sh :: LINES 700-1139 - action handlers (do_init, do_push, etc.)
-DETAIL:sync-shuttle.sh :: DEPENDS lib/core.sh; lib/logging.sh; lib/validation.sh; lib/transfer.sh; lib/s3.sh
+FILE :: bucketcast.sh | Main CLI executable; orchestrates all operations | LOC:./bucketcast.sh:1139 | CONTAINS:argument_parsing,action_dispatch,init,push,pull,list,status | EXPORTS:SYNC_BASE_DIR,CONFIG_DIR,LOGS_DIR
+DETAIL:bucketcast.sh :: LINES 1-310 - embedded man-style documentation
+DETAIL:bucketcast.sh :: LINES 310-500 - global variables and library sourcing
+DETAIL:bucketcast.sh :: LINES 500-700 - argument parsing
+DETAIL:bucketcast.sh :: LINES 700-1139 - action handlers (do_init, do_push, etc.)
+DETAIL:bucketcast.sh :: DEPENDS lib/core.sh; lib/logging.sh; lib/validation.sh; lib/transfer.sh; lib/s3.sh
 
 FILE :: install.sh | Curl-able installer script | LOC:./install.sh:225 | CONTAINS:download,extract,setup_paths,create_wrapper | EXPORTS:none
 DETAIL:install.sh :: USAGE curl -fsSL URL/install.sh | bash
-DETAIL:install.sh :: CREATES ~/.local/share/sync-shuttle/ (installation)
-DETAIL:install.sh :: CREATES ~/.local/bin/sync-shuttle (wrapper script)
+DETAIL:install.sh :: CREATES ~/.local/share/bucketcast/ (installation)
+DETAIL:install.sh :: CREATES ~/.local/bin/bucketcast (wrapper script)
 DETAIL:install.sh :: MODIFIES ~/.bashrc or ~/.zshrc (PATH addition)
 
 TOPIC :: LIBRARY_MODULES
@@ -188,17 +188,17 @@ TOPIC :: CONFIGURATION_FILES
 TOPIC_DESCRIPTION :: Example configuration templates
 TOPIC_FILES :: config/*.example
 
-FILE :: config/sync-shuttle.conf.example | Main configuration template | LOC:./config/sync-shuttle.conf.example:111 | CONTAINS:path_settings,ssh_defaults,rsync_options,logging_config,s3_settings
+FILE :: config/bucketcast.conf.example | Main configuration template | LOC:./config/bucketcast.conf.example:111 | CONTAINS:path_settings,ssh_defaults,rsync_options,logging_config,s3_settings
 FILE :: config/servers.conf.example | Server definition template | LOC:./config/servers.conf.example:110 | CONTAINS:server_declarations,identity_file_support
-FILE :: config/.syncshuttlerc.example | User-level defaults | LOC:./config/.syncshuttlerc.example:45 | CONTAINS:ssh_default_identity,behavior_flags
+FILE :: config/.bucketcastrc.example | User-level defaults | LOC:./config/.bucketcastrc.example:45 | CONTAINS:ssh_default_identity,behavior_flags
 
 TOPIC :: TUI_COMPONENTS
 TOPIC_DESCRIPTION :: Python terminal user interface
-TOPIC_FILES :: tui/sync_tui.py; tui/requirements.txt
+TOPIC_FILES :: tui/bucketcast_tui.py; tui/requirements.txt
 
-FILE :: tui/sync_tui.py | Terminal user interface | LOC:./tui/sync_tui.py:666 | CONTAINS:ServerConfig,SyncOperation,MainScreen,PushScreen,PullScreen,FileBrowser | EXPORTS:main
-DETAIL:tui/sync_tui.py :: KEYBINDS q=quit; p=push; l=pull; r=refresh
-DETAIL:tui/sync_tui.py :: REQUIRES textual>=0.40.0; rich>=13.0.0
+FILE :: tui/bucketcast_tui.py | Terminal user interface | LOC:./tui/bucketcast_tui.py:666 | CONTAINS:ServerConfig,SyncOperation,MainScreen,PushScreen,PullScreen,FileBrowser | EXPORTS:main
+DETAIL:tui/bucketcast_tui.py :: KEYBINDS q=quit; p=push; l=pull; r=refresh
+DETAIL:tui/bucketcast_tui.py :: REQUIRES textual>=0.40.0; rich>=13.0.0
 
 ================================================================================
 [FUNCTION_REFERENCE]
@@ -315,12 +315,12 @@ TOPIC :: MAIN_COMMANDS
 TOPIC_DESCRIPTION :: Primary CLI commands
 TOPIC_RELATED :: EXIT_CODES
 
-CMD :: sync-shuttle init | Initialize sync-shuttle directory structure | CREATES:~/.sync-shuttle/* | IDEMPOTENT:yes | EXIT:0_success,1_failure
-DETAIL:init :: CREATES ~/.sync-shuttle/ and all subdirectories
+CMD :: bucketcast init | Initialize bucketcast directory structure | CREATES:~/.bucketcast/* | IDEMPOTENT:yes | EXIT:0_success,1_failure
+DETAIL:init :: CREATES ~/.bucketcast/ and all subdirectories
 DETAIL:init :: CREATES default configuration files from examples
 DETAIL:init :: SAFE to run multiple times - skips existing
 
-CMD :: sync-shuttle push --server <id> --source <path> | Push files to remote server | REQUIRES:--server,--source | EXIT:0-8
+CMD :: bucketcast push --server <id> --source <path> | Push files to remote server | REQUIRES:--server,--source | EXIT:0-8
 DETAIL:push :: REQUIRED --server <id> - target server from servers.conf
 DETAIL:push :: REQUIRED --source <path> - local file or directory
 DETAIL:push :: OPTIONAL --dry-run - simulate without transferring
@@ -330,21 +330,21 @@ DETAIL:push :: OPTIONAL --quiet - minimal output
 DETAIL:push :: OPTIONAL --s3-archive - archive to S3 after transfer
 DETAIL:push :: FLOW validate -> preflight -> stage_local -> rsync_remote -> log
 
-CMD :: sync-shuttle pull --server <id> | Pull files from remote server | REQUIRES:--server | EXIT:0-8
+CMD :: bucketcast pull --server <id> | Pull files from remote server | REQUIRES:--server | EXIT:0-8
 DETAIL:pull :: REQUIRED --server <id> - source server from servers.conf
 DETAIL:pull :: OPTIONAL same as push (--dry-run, --force, etc.)
 DETAIL:pull :: FLOW validate -> preflight -> rsync_from_remote -> stage_local -> log
 
-CMD :: sync-shuttle list servers | Display all configured servers | EXIT:0_success,1_no_servers
+CMD :: bucketcast list servers | Display all configured servers | EXIT:0_success,1_no_servers
 DETAIL:list_servers :: OUTPUT table of server id; name; host; enabled status
 
-CMD :: sync-shuttle list files --server <id> | Display synced files for server | REQUIRES:--server | EXIT:0_success,1_error
+CMD :: bucketcast list files --server <id> | Display synced files for server | REQUIRES:--server | EXIT:0_success,1_error
 DETAIL:list_files :: OUTPUT tree view of SYNC_BASE_DIR/remote/{server_id}/files/
 
-CMD :: sync-shuttle status | Display overall sync-shuttle status | EXIT:0_always
+CMD :: bucketcast status | Display overall bucketcast status | EXIT:0_always
 DETAIL:status :: OUTPUT directory sizes; last operations; server count
 
-CMD :: sync-shuttle tui | Launch terminal user interface | REQUIRES:python3,textual,rich | EXIT:0_clean,1_error
+CMD :: bucketcast tui | Launch terminal user interface | REQUIRES:python3,textual,rich | EXIT:0_clean,1_error
 DETAIL:tui :: KEYBINDS q=quit; p=push; l=pull; r=refresh
 
 TOPIC :: EXIT_CODES
@@ -353,7 +353,7 @@ TOPIC_DESCRIPTION :: Exit code meanings for all commands
 EXIT :: 0 | Success - operation completed normally
 EXIT :: 1 | General error - unspecified failure
 EXIT :: 2 | Invalid arguments - missing required flags; invalid values
-EXIT :: 3 | Not initialized - run sync-shuttle init first
+EXIT :: 3 | Not initialized - run bucketcast init first
 EXIT :: 4 | Server not found - server_id not in servers.conf or disabled
 EXIT :: 5 | Transfer failed - rsync/SSH error during transfer
 EXIT :: 6 | Collision - destination file exists; use --force
@@ -372,7 +372,7 @@ DETAIL:ServerConfig :: FIELD host (string) - hostname or IP address; REQUIRED
 DETAIL:ServerConfig :: FIELD port (integer) - SSH port; default 22
 DETAIL:ServerConfig :: FIELD user (string) - SSH username; REQUIRED
 DETAIL:ServerConfig :: FIELD identity_file (string) - path to SSH key; optional; supports ~
-DETAIL:ServerConfig :: FIELD remote_base (string) - remote sync-shuttle directory path
+DETAIL:ServerConfig :: FIELD remote_base (string) - remote bucketcast directory path
 DETAIL:ServerConfig :: FIELD enabled (boolean) - true/false
 DETAIL:ServerConfig :: FIELD s3_backup (boolean) - archive to S3 after sync
 DETAIL:ServerConfig :: SYNTAX declare -A server_<id>=([name]="..." [host]="..." ...)
@@ -393,7 +393,7 @@ DETAIL:LogEntry :: FIELD rsync_exit_code (integer)
 ================================================================================
 SECTION_TYPE :: HYBRID
 
-CONFIG :: SYNC_BASE_DIR | Root directory for all sync-shuttle data | DEFAULT:~/.sync-shuttle
+CONFIG :: SYNC_BASE_DIR | Root directory for all bucketcast data | DEFAULT:~/.bucketcast
 CONFIG :: LOG_LEVEL | Minimum level for log output | DEFAULT:INFO | VALUES:DEBUG|INFO|WARN|ERROR
 CONFIG :: MAX_TRANSFER_SIZE | Maximum allowed single transfer size | DEFAULT:10G | FORMAT:number with K/M/G
 CONFIG :: SSH_CONNECT_TIMEOUT | Seconds to wait for SSH connection | DEFAULT:10
@@ -409,7 +409,7 @@ CONFIG :: ARCHIVE_RETENTION_DAYS | Days to keep local archives | DEFAULT:30
 SECTION_TYPE :: MANUAL
 
 FLOW :: PUSH_OPERATION | User invokes push; files transferred to remote
-DETAIL:PUSH_OPERATION :: STEP 1 - User: sync-shuttle push --server <id> --source <path>
+DETAIL:PUSH_OPERATION :: STEP 1 - User: bucketcast push --server <id> --source <path>
 DETAIL:PUSH_OPERATION :: STEP 2 - Parse arguments; set DRY_RUN, FORCE, VERBOSE flags
 DETAIL:PUSH_OPERATION :: STEP 3 - validate_environment() - check bash, tools, directories
 DETAIL:PUSH_OPERATION :: STEP 4 - validate_server_id() - format check
@@ -436,7 +436,7 @@ DETAIL:PULL_OPERATION :: STEP 11-14 - Same logging and cleanup as push
 SECTION_TYPE :: MANUAL
 
 TOPIC :: SAFETY_FEATURES
-TOPIC_DESCRIPTION :: All security and safety mechanisms in sync-shuttle
+TOPIC_DESCRIPTION :: All security and safety mechanisms in bucketcast
 TOPIC_RELATED :: VALIDATION_FUNCTIONS
 
 SAFETY :: NO_DELETE_GUARANTEE | rsync never invoked with --delete flag | LOC:lib/transfer.sh:build_rsync_options | ENFORCEMENT:hardcoded
@@ -478,22 +478,22 @@ DETAIL:NO_BACKGROUND_OPERATIONS :: RATIONALE user always knows when files move
 ================================================================================
 SECTION_TYPE :: MANUAL
 
-FAQ :: What is sync-shuttle?
+FAQ :: What is bucketcast?
 FAQ_ANSWER :: CLI file synchronization tool wrapping rsync with safety guardrails | NEVER deletes files | NEVER overwrites without consent | Full audit trail
 
 FAQ :: How do I install?
-FAQ_ANSWER :: curl -fsSL URL/install.sh | bash OR git clone && ./sync-shuttle.sh init | Creates ~/.sync-shuttle/ structure
+FAQ_ANSWER :: curl -fsSL URL/install.sh | bash OR git clone && ./bucketcast.sh init | Creates ~/.bucketcast/ structure
 
 FAQ :: How do I add a server?
-FAQ_ANSWER :: Edit ~/.sync-shuttle/config/servers.conf | Add declare -A server_<id>=([host]="..." [user]="..." [remote_base]="..." [enabled]="true") | Minimum: host, user, remote_base, enabled
+FAQ_ANSWER :: Edit ~/.bucketcast/config/servers.conf | Add declare -A server_<id>=([host]="..." [user]="..." [remote_base]="..." [enabled]="true") | Minimum: host, user, remote_base, enabled
 
 FAQ :: How do I push files?
-FAQ_ANSWER :: sync-shuttle push --server <id> --source <path> | Always test with --dry-run first | Files go to remote:remote_base/local/inbox/hostname/
+FAQ_ANSWER :: bucketcast push --server <id> --source <path> | Always test with --dry-run first | Files go to remote:remote_base/local/inbox/hostname/
 
 FAQ :: How do I pull files?
-FAQ_ANSWER :: sync-shuttle pull --server <id> | Files arrive at ~/.sync-shuttle/local/inbox/<server_id>/
+FAQ_ANSWER :: bucketcast pull --server <id> | Files arrive at ~/.bucketcast/local/inbox/<server_id>/
 
-FAQ :: Can sync-shuttle delete remote files?
+FAQ :: Can bucketcast delete remote files?
 FAQ_ANSWER :: NO - core safety guarantee | rsync NEVER invoked with --delete | Use ssh directly for deletions
 
 FAQ :: What does --force do?
@@ -506,7 +506,7 @@ FAQ :: How do I use SSH keys?
 FAQ_ANSWER :: In servers.conf: [identity_file]="~/.ssh/mykey.pem" | Supports ~ expansion | Key must be readable, permissions 600/400
 
 FAQ :: Where are logs?
-FAQ_ANSWER :: Human: ~/.sync-shuttle/logs/sync.log | Machine: ~/.sync-shuttle/logs/sync.jsonl | Query: jq '.status' sync.jsonl
+FAQ_ANSWER :: Human: ~/.bucketcast/logs/sync.log | Machine: ~/.bucketcast/logs/sync.jsonl | Query: jq '.status' sync.jsonl
 
 FAQ :: What are the exit codes?
 FAQ_ANSWER :: 0=success | 1=general error | 2=invalid args | 3=not init | 4=server not found | 5=transfer failed | 6=collision | 7=validation failed | 8=dependency missing
@@ -515,7 +515,7 @@ FAQ :: How do I run tests?
 FAQ_ANSWER :: ./tests/run_tests.sh [unit|integration|e2e] | All tests: ./tests/run_tests.sh
 
 FAQ :: Where is the entry point?
-FAQ_ANSWER :: sync-shuttle.sh | Line ~400: library sourcing | Line ~500: argument parsing | Line ~700: action dispatch
+FAQ_ANSWER :: bucketcast.sh | Line ~400: library sourcing | Line ~500: argument parsing | Line ~700: action dispatch
 
 FAQ :: How do I add a new command?
 FAQ_ANSWER :: 1. Add case in dispatch (~line 700) | 2. Create do_<action> function | 3. Add to help text | 4. Add tests | 5. Update llm.txt
@@ -548,7 +548,7 @@ EDGE :: CTRL+C during operation | Trap catches; cleanup runs | LOGGED:partial | 
 SECTION_TYPE :: MANUAL
 
 MOD :: Adding a new CLI flag
-DETAIL:new_flag :: STEP 1 - Edit sync-shuttle.sh argument parsing (~line 500)
+DETAIL:new_flag :: STEP 1 - Edit bucketcast.sh argument parsing (~line 500)
 DETAIL:new_flag :: STEP 2 - Add case: --newflag) NEWFLAG="true"; shift ;;
 DETAIL:new_flag :: STEP 3 - Initialize: NEWFLAG="${NEWFLAG:-false}"
 DETAIL:new_flag :: STEP 4 - Add to help text (~line 430)

--- a/bucketcast.sh
+++ b/bucketcast.sh
@@ -9,16 +9,16 @@
 #   ╚══════╝   ╚═╝   ╚═╝  ╚═══╝ ╚═════╝    ╚══════╝╚═╝  ╚═╝ ╚═════╝    ╚═╝      ╚═╝   ╚══════╝╚══════╝
 #
 #===============================================================================
-# SYNC SHUTTLE - Safe, Idempotent File Synchronization Tool
+# BUCKETCAST - Safe, Idempotent File Synchronization Tool
 #===============================================================================
 # Version:     1.0.0
-# Author:      Sync Shuttle Contributors
+# Author:      Bucketcast Contributors
 # License:     MIT
 # Repository:  https://github.com/kaurifund/bucketcast
 #===============================================================================
 #
 # DESCRIPTION:
-#   Sync Shuttle is a safe, manual file synchronization tool for transferring
+#   Bucketcast is a safe, manual file synchronization tool for transferring
 #   files between a home computer and remote servers. It prioritizes safety
 #   and auditability over speed, ensuring files are never accidentally deleted
 #   or overwritten.
@@ -28,7 +28,7 @@
 #-------------------------------------------------------------------------------
 #
 #   ┌─────────────────────────────────────────────────────────────────────────┐
-#   │                           SYNC SHUTTLE FLOW                             │
+#   │                           BUCKETCAST FLOW                             │
 #   └─────────────────────────────────────────────────────────────────────────┘
 #
 #   [CLI Input] ──► [Validation] ──► [Path Resolution] ──► [Safety Checks]
@@ -43,9 +43,9 @@
 # DIRECTORY STRUCTURE (RUNTIME):
 #-------------------------------------------------------------------------------
 #
-#   ~/.sync-shuttle/
+#   ~/.bucketcast/
 #   ├── config/
-#   │   ├── sync-shuttle.conf    # Main configuration (sourced)
+#   │   ├── bucketcast.conf    # Main configuration (sourced)
 #   │   └── servers.toml         # Server definitions (sourced)
 #   ├── remote/
 #   │   └── <server_id>/
@@ -101,7 +101,7 @@
 #   │       Shows current sync status and recent operations.
 #   │
 #   └── action_init()
-#           Initializes the ~/.sync-shuttle directory structure.
+#           Initializes the ~/.bucketcast directory structure.
 #
 #-------------------------------------------------------------------------------
 # SAFETY FUNCTIONS:
@@ -161,37 +161,37 @@
 # USAGE EXAMPLES:
 #-------------------------------------------------------------------------------
 #
-#   # Initialize sync-shuttle (first time setup)
-#   ./sync-shuttle.sh init
+#   # Initialize bucketcast (first time setup)
+#   ./bucketcast.sh init
 #
 #   # List all configured servers
-#   ./sync-shuttle.sh list servers
+#   ./bucketcast.sh list servers
 #
 #   # Push a file to a server (dry-run first!)
-#   ./sync-shuttle.sh push --server myserver --source ~/file.txt --dry-run
-#   ./sync-shuttle.sh push --server myserver --source ~/file.txt
+#   ./bucketcast.sh push --server myserver --source ~/file.txt --dry-run
+#   ./bucketcast.sh push --server myserver --source ~/file.txt
 #
 #   # Push a directory
-#   ./sync-shuttle.sh push --server myserver --source ~/myproject/ --dry-run
+#   ./bucketcast.sh push --server myserver --source ~/myproject/ --dry-run
 #
 #   # Pull files from a server
-#   ./sync-shuttle.sh pull --server myserver --dry-run
-#   ./sync-shuttle.sh pull --server myserver
+#   ./bucketcast.sh pull --server myserver --dry-run
+#   ./bucketcast.sh pull --server myserver
 #
 #   # Pull with force (allow overwrites, will prompt)
-#   ./sync-shuttle.sh pull --server myserver --force
+#   ./bucketcast.sh pull --server myserver --force
 #
 #   # View sync status and recent operations
-#   ./sync-shuttle.sh status
+#   ./bucketcast.sh status
 #
 #   # View files on a specific server's local mirror
-#   ./sync-shuttle.sh list files --server myserver
+#   ./bucketcast.sh list files --server myserver
 #
 #   # Launch interactive TUI (requires Python)
-#   ./sync-shuttle.sh tui
+#   ./bucketcast.sh tui
 #
 #   # Verbose mode for debugging
-#   ./sync-shuttle.sh push --server myserver --source ~/file.txt --verbose
+#   ./bucketcast.sh push --server myserver --source ~/file.txt --verbose
 #
 #-------------------------------------------------------------------------------
 # USE CASE PATTERNS:
@@ -202,57 +202,57 @@
 #   Scenario: Push code changes to remote dev server daily
 #   
 #   # Stage files in outbox
-#   cp -r ~/projects/myapp ~/.sync-shuttle/local/outbox/
+#   cp -r ~/projects/myapp ~/.bucketcast/local/outbox/
 #   
 #   # Dry-run to verify
-#   ./sync-shuttle.sh push --server devbox --dry-run
+#   ./bucketcast.sh push --server devbox --dry-run
 #   
 #   # Execute
-#   ./sync-shuttle.sh push --server devbox
+#   ./bucketcast.sh push --server devbox
 #
 #   PATTERN 2: Backup Pull from Production
 #   ───────────────────────────────────────
 #   Scenario: Pull config files from production for backup
 #   
 #   # Pull configs (they land in inbox)
-#   ./sync-shuttle.sh pull --server prod-web-01
+#   ./bucketcast.sh pull --server prod-web-01
 #   
 #   # Files available at:
-#   ls ~/.sync-shuttle/local/inbox/prod-web-01/
+#   ls ~/.bucketcast/local/inbox/prod-web-01/
 #
 #   PATTERN 3: Multi-Server Distribution
 #   ─────────────────────────────────────
 #   Scenario: Push same files to multiple servers
 #   
 #   for server in web-01 web-02 web-03; do
-#       ./sync-shuttle.sh push --server "$server" --source ~/deploy/
+#       ./bucketcast.sh push --server "$server" --source ~/deploy/
 #   done
 #
 #   PATTERN 4: S3 Archive After Sync (if enabled)
 #   ──────────────────────────────────────────────
 #   Scenario: Archive to S3 after successful sync
 #   
-#   ./sync-shuttle.sh push --server myserver --source ~/data/ --s3-archive
+#   ./bucketcast.sh push --server myserver --source ~/data/ --s3-archive
 #
 #   PATTERN 5: Collision Handling
 #   ─────────────────────────────
 #   Scenario: File exists at destination
 #   
 #   # Without --force: skips existing files, logs as SKIPPED
-#   ./sync-shuttle.sh pull --server myserver
+#   ./bucketcast.sh pull --server myserver
 #   
 #   # With --force: prompts for confirmation, archives old version
-#   ./sync-shuttle.sh pull --server myserver --force
+#   ./bucketcast.sh pull --server myserver --force
 #
 #-------------------------------------------------------------------------------
 # CONFIGURATION REFERENCE:
 #-------------------------------------------------------------------------------
 #
-#   sync-shuttle.conf variables:
+#   bucketcast.conf variables:
 #   ┌─────────────────────┬────────────────────────────────────────────────┐
 #   │ Variable            │ Description                                    │
 #   ├─────────────────────┼────────────────────────────────────────────────┤
-#   │ SYNC_BASE_DIR       │ Base directory (default: ~/.sync-shuttle)     │
+#   │ SYNC_BASE_DIR       │ Base directory (default: ~/.bucketcast)     │
 #   │ DEFAULT_SSH_PORT    │ Default SSH port (default: 22)                │
 #   │ RSYNC_OPTIONS       │ Additional rsync flags                        │
 #   │ LOG_LEVEL           │ Logging verbosity (DEBUG|INFO|WARN|ERROR)     │
@@ -270,7 +270,7 @@
 #   │ host=192.168.1.100                                                  │
 #   │ port=22                                                             │
 #   │ user=deploy                                                         │
-#   │ remote_base=/home/deploy/.sync-shuttle                              │
+#   │ remote_base=/home/deploy/.bucketcast                              │
 #   │ enabled=true                                                        │
 #   │ s3_backup=false                                                     │
 #   └──────────────────────────────────────────────────────────────────────┘
@@ -316,20 +316,20 @@ set -o pipefail  # Exit on pipe failure
 #===============================================================================
 # SCRIPT METADATA
 #===============================================================================
-readonly SCRIPT_NAME="sync-shuttle"
+readonly SCRIPT_NAME="bucketcast"
 readonly SCRIPT_VERSION="1.2.0"
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 #===============================================================================
 # DEFAULT CONFIGURATION (can be overridden by config file)
 #===============================================================================
-SYNC_BASE_DIR="${SYNC_BASE_DIR:-$HOME/.sync-shuttle}"
+SYNC_BASE_DIR="${SYNC_BASE_DIR:-$HOME/.bucketcast}"
 DEFAULT_SSH_PORT=22
 RSYNC_OPTIONS="-avz --partial --progress"
 LOG_LEVEL="INFO"
 S3_ENABLED="false"
 S3_BUCKET=""
-S3_PREFIX="sync-shuttle-archive"
+S3_PREFIX="bucketcast-archive"
 ARCHIVE_RETENTION_DAYS=30
 MAX_TRANSFER_SIZE="10G"
 
@@ -417,13 +417,13 @@ source_library "s3.sh"
 #===============================================================================
 show_usage() {
     cat << EOF
-${BOLD}SYNC SHUTTLE${RESET} - Safe, Idempotent File Synchronization
+${BOLD}BUCKETCAST${RESET} - Safe, Idempotent File Synchronization
 
 ${BOLD}USAGE:${RESET}
     $SCRIPT_NAME <command> [options]
 
 ${BOLD}COMMANDS:${RESET}
-    init                    Initialize sync-shuttle directory structure
+    init                    Initialize bucketcast directory structure
     push                    Push files TO a remote server
     pull                    Pull files FROM a remote server
     share                   Share files via outbox (for others to pull)
@@ -477,7 +477,7 @@ ${BOLD}EXAMPLES:${RESET}
     $SCRIPT_NAME share --list
 
 ${BOLD}SAFETY:${RESET}
-    • All operations are sandboxed to ~/.sync-shuttle/
+    • All operations are sandboxed to ~/.bucketcast/
     • Files are NEVER deleted by this tool
     • Existing files are NEVER overwritten without --force
     • Use --dry-run to preview any operation
@@ -647,7 +647,7 @@ content = sys.stdin.read()
 pattern = r"declare\s+-A\s+server_(\w+)=\(\s*([^)]+)\)"
 matches = re.findall(pattern, content, re.DOTALL)
 
-print("# Sync Shuttle - Server Configuration")
+print("# Bucketcast - Server Configuration")
 print("# Migrated from servers.conf")
 print("")
 
@@ -713,7 +713,7 @@ migrate_outbox_to_global() {
 
 # Run all necessary migrations based on version
 check_and_run_migrations() {
-    # Skip if sync-shuttle directory doesn't exist (fresh install)
+    # Skip if bucketcast directory doesn't exist (fresh install)
     [[ ! -d "$SYNC_BASE_DIR" ]] && return 0
 
     local installed_version
@@ -758,7 +758,7 @@ initialize_paths() {
 }
 
 load_configuration() {
-    local config_file="${CONFIG_DIR}/sync-shuttle.conf"
+    local config_file="${CONFIG_DIR}/bucketcast.conf"
     
     if [[ -f "$config_file" ]]; then
         log_debug "Loading configuration from: $config_file"
@@ -822,7 +822,7 @@ validate_server_required() {
 # ACTION: INIT
 #===============================================================================
 action_init() {
-    log_info "Initializing Sync Shuttle directory structure..."
+    log_info "Initializing Bucketcast directory structure..."
     
     # Create all directories
     local dirs=(
@@ -850,7 +850,7 @@ action_init() {
     log_debug "Set secure permissions on config directory"
     
     # Create default config if not exists
-    local config_file="${CONFIG_DIR}/sync-shuttle.conf"
+    local config_file="${CONFIG_DIR}/bucketcast.conf"
     if [[ ! -f "$config_file" ]]; then
         create_default_config "$config_file"
         log_info "Created default configuration: $config_file"
@@ -875,7 +875,7 @@ action_init() {
     # Write version file (append with timestamp)
     update_version_file
 
-    log_success "Sync Shuttle initialized successfully!"
+    log_success "Bucketcast initialized successfully!"
     echo ""
     echo "Next steps:"
     echo "  1. Edit ${CONFIG_DIR}/servers.toml to add your servers"
@@ -888,16 +888,16 @@ create_default_config() {
     
     cat > "$config_file" << 'DEFAULTCONFIG'
 #===============================================================================
-# SYNC SHUTTLE CONFIGURATION
+# BUCKETCAST CONFIGURATION
 #===============================================================================
-# This file is sourced by sync-shuttle.sh
+# This file is sourced by bucketcast.sh
 # Edit values below to customize behavior
 
 #-------------------------------------------------------------------------------
 # Base Paths
 #-------------------------------------------------------------------------------
-# Base directory for all sync-shuttle data (default: ~/.sync-shuttle)
-# SYNC_BASE_DIR="$HOME/.sync-shuttle"
+# Base directory for all bucketcast data (default: ~/.bucketcast)
+# SYNC_BASE_DIR="$HOME/.bucketcast"
 
 #-------------------------------------------------------------------------------
 # SSH Settings
@@ -924,10 +924,10 @@ LOG_LEVEL="INFO"
 S3_ENABLED="false"
 
 # S3 bucket name (required if S3_ENABLED=true)
-# S3_BUCKET="my-sync-shuttle-bucket"
+# S3_BUCKET="my-bucketcast-bucket"
 
 # S3 key prefix for archived files
-S3_PREFIX="sync-shuttle-archive"
+S3_PREFIX="bucketcast-archive"
 
 #-------------------------------------------------------------------------------
 # Archive Settings
@@ -947,7 +947,7 @@ create_default_servers_config() {
     local servers_file="$1"
 
     cat > "$servers_file" << 'DEFAULTSERVERS'
-# Sync Shuttle - Server Configuration
+# Bucketcast - Server Configuration
 # ====================================
 # Each [servers.ID] section defines a server.
 # ID must be lowercase alphanumeric with dashes (3-32 chars).
@@ -962,7 +962,7 @@ create_default_servers_config() {
 #   port = 22
 #   user = "ec2-user"
 #   identity_file = "~/.ssh/my-key.pem"
-#   remote_base = "/home/ec2-user/.sync-shuttle"
+#   remote_base = "/home/ec2-user/.bucketcast"
 #   enabled = true
 #   s3_backup = true
 
@@ -971,7 +971,7 @@ name = "Example Server"
 host = "192.168.1.100"
 port = 22
 user = "myuser"
-remote_base = "/home/myuser/.sync-shuttle"
+remote_base = "/home/myuser/.bucketcast"
 enabled = false
 s3_backup = false
 
@@ -1372,7 +1372,7 @@ list_server_files() {
 #===============================================================================
 action_status() {
     echo ""
-    echo "${BOLD}Sync Shuttle Status${RESET}"
+    echo "${BOLD}Bucketcast Status${RESET}"
     echo "═════════════════════════════════════════════════════════"
     echo ""
     
@@ -1503,7 +1503,7 @@ action_config() {
 # ACTION: TUI
 #===============================================================================
 action_tui() {
-    local tui_script="${SCRIPT_DIR}/tui/sync_tui.py"
+    local tui_script="${SCRIPT_DIR}/tui/bucketcast_tui.py"
     local venv_python="${SCRIPT_DIR}/.venv/bin/python"
 
     if [[ ! -f "$tui_script" ]]; then

--- a/config/.bucketcastrc.example
+++ b/config/.bucketcastrc.example
@@ -1,17 +1,17 @@
 #===============================================================================
-# SYNC SHUTTLE - USER CONFIGURATION
+# BUCKETCAST - USER CONFIGURATION
 #===============================================================================
-# User-level defaults for sync-shuttle.
+# User-level defaults for bucketcast.
 #
-# Location: ~/.syncshuttlerc (loaded automatically if present)
+# Location: ~/.bucketcastrc (loaded automatically if present)
 #
 # This file is sourced BEFORE the main config, allowing you to set
 # user-specific defaults that can be overridden per-project.
 #
 # Priority (lowest to highest):
 #   1. Built-in defaults
-#   2. ~/.syncshuttlerc (this file)
-#   3. ~/.sync-shuttle/config/sync-shuttle.conf
+#   2. ~/.bucketcastrc (this file)
+#   3. ~/.bucketcast/config/bucketcast.conf
 #   4. Command-line flags
 #===============================================================================
 
@@ -20,12 +20,12 @@
 #-------------------------------------------------------------------------------
 
 # Your preferred editor for config files
-# SYNC_SHUTTLE_EDITOR="${EDITOR:-nano}"
+# BUCKETCAST_EDITOR="${EDITOR:-nano}"
 
 # Default behavior flags
-# SYNC_SHUTTLE_DRY_RUN_DEFAULT="false"    # Always start in dry-run mode
-# SYNC_SHUTTLE_VERBOSE_DEFAULT="false"    # Verbose output by default
-# SYNC_SHUTTLE_CONFIRM_FORCE="true"       # Require confirmation for --force
+# BUCKETCAST_DRY_RUN_DEFAULT="false"    # Always start in dry-run mode
+# BUCKETCAST_VERBOSE_DEFAULT="false"    # Verbose output by default
+# BUCKETCAST_CONFIRM_FORCE="true"       # Require confirmation for --force
 
 #-------------------------------------------------------------------------------
 # SSH Defaults
@@ -67,12 +67,12 @@
 # Aliases / Shortcuts
 #-------------------------------------------------------------------------------
 # Define quick aliases for frequently used servers
-# These can be used with: sync-shuttle push -s @work
+# These can be used with: bucketcast push -s @work
 #
 # Example:
-# SYNC_SHUTTLE_ALIAS_WORK="my-work-server"
-# SYNC_SHUTTLE_ALIAS_HOME="home-nas"
-# SYNC_SHUTTLE_ALIAS_PI="raspberry-pi-4"
+# BUCKETCAST_ALIAS_WORK="my-work-server"
+# BUCKETCAST_ALIAS_HOME="home-nas"
+# BUCKETCAST_ALIAS_PI="raspberry-pi-4"
 
 #===============================================================================
 # END OF USER CONFIGURATION

--- a/config/bucketcast.conf.example
+++ b/config/bucketcast.conf.example
@@ -1,19 +1,19 @@
 #===============================================================================
-# SYNC SHUTTLE CONFIGURATION
+# BUCKETCAST CONFIGURATION
 #===============================================================================
-# This file is sourced by sync-shuttle.sh
+# This file is sourced by bucketcast.sh
 # Edit values below to customize behavior
 #
-# Location: ~/.sync-shuttle/config/sync-shuttle.conf
+# Location: ~/.bucketcast/config/bucketcast.conf
 #===============================================================================
 
 #-------------------------------------------------------------------------------
 # Base Paths
 #-------------------------------------------------------------------------------
-# Base directory for all sync-shuttle data
-# Default: ~/.sync-shuttle
+# Base directory for all bucketcast data
+# Default: ~/.bucketcast
 # Uncomment to override:
-# SYNC_BASE_DIR="$HOME/.sync-shuttle"
+# SYNC_BASE_DIR="$HOME/.bucketcast"
 
 #-------------------------------------------------------------------------------
 # SSH Settings
@@ -59,10 +59,10 @@ LOG_KEEP_FILES=5
 S3_ENABLED="false"
 
 # S3 bucket name for archives (required if S3_ENABLED=true)
-# S3_BUCKET="my-sync-shuttle-bucket"
+# S3_BUCKET="my-bucketcast-bucket"
 
 # S3 key prefix for all archived files
-S3_PREFIX="sync-shuttle-archive"
+S3_PREFIX="bucketcast-archive"
 
 # S3 storage class for archives
 # Options: STANDARD, STANDARD_IA, ONEZONE_IA, GLACIER, DEEP_ARCHIVE

--- a/config/servers.toml.example
+++ b/config/servers.toml.example
@@ -1,6 +1,6 @@
-# Sync Shuttle - Server Configuration
+# Bucketcast - Server Configuration
 # ====================================
-# Copy this file to ~/.sync-shuttle/config/servers.toml and edit.
+# Copy this file to ~/.bucketcast/config/servers.toml and edit.
 #
 # Each [servers.ID] section defines a server.
 # ID must be lowercase alphanumeric with dashes (3-32 chars).
@@ -11,7 +11,7 @@ host = "192.168.1.100"           # IP address or hostname
 port = 22                        # SSH port
 user = "myuser"                  # SSH username
 identity_file = "~/.ssh/id_rsa" # SSH key path (.pem, id_rsa, id_ed25519, etc.)
-# remote_base = "/home/myuser/.sync-shuttle"  # Optional: defaults to /home/<user>/.sync-shuttle
+# remote_base = "/home/myuser/.bucketcast"  # Optional: defaults to /home/<user>/.bucketcast
 enabled = false                  # Set to true to activate this server
 s3_backup = false                # Archive synced files to S3
 
@@ -23,7 +23,7 @@ host = "ec2-12-34-56-78.compute-1.amazonaws.com"
 port = 22
 user = "ec2-user"
 identity_file = "~/.ssh/aws-prod.pem"
-remote_base = "/home/ec2-user/.sync-shuttle"
+remote_base = "/home/ec2-user/.bucketcast"
 enabled = false
 s3_backup = true
 
@@ -33,6 +33,6 @@ host = "192.168.1.50"
 port = 22
 user = "admin"
 # identity_file = ""  # Omit to use default SSH key from agent
-remote_base = "/home/admin/.sync-shuttle"
+remote_base = "/home/admin/.bucketcast"
 enabled = false
 s3_backup = false

--- a/install.sh
+++ b/install.sh
@@ -215,7 +215,7 @@ print_completion() {
         echo -e "${YELLOW}════════════════════════════════════════════════════════════${RESET}"
         echo -e "${YELLOW}${BOLD}WARNING: You installed from branch '${BRANCH}'${RESET}"
         echo -e "${YELLOW}This is not the stable main branch. For production use:${RESET}"
-        echo -e "${YELLOW}  curl -fsSL .../main/install.sh | bash${RESET}"
+        echo -e "${YELLOW}  curl -fsSL https://raw.githubusercontent.com/kaurifund/bucketcast/main/install.sh | bash${RESET}"
         echo -e "${YELLOW}════════════════════════════════════════════════════════════${RESET}"
         echo ""
     fi

--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,9 @@ set -o pipefail
 # CONFIGURATION
 #===============================================================================
 readonly REPO_URL="${SYNC_SHUTTLE_REPO:-https://github.com/kaurifund/bucketcast}"
-readonly BRANCH="${SYNC_SHUTTLE_BRANCH:-main}"
+# TODO: Uncomment below and delete feature branch line when merging to main
+#readonly BRANCH="${SYNC_SHUTTLE_BRANCH:-main}"
+readonly BRANCH="${SYNC_SHUTTLE_BRANCH:-feature/outbox-inbox-symmetry}"
 readonly INSTALL_DIR="${SYNC_SHUTTLE_DIR:-$HOME/.local/share/sync-shuttle}"
 readonly BIN_DIR="${HOME}/.local/bin"
 readonly NO_RC="${SYNC_SHUTTLE_NO_RC:-false}"

--- a/install.sh
+++ b/install.sh
@@ -209,6 +209,16 @@ print_completion() {
     echo ""
     echo -e "${BOLD}Documentation:${RESET} ${INSTALL_DIR}/README.md"
     echo ""
+
+    # Warn if not on main branch
+    if [[ "$BRANCH" != "main" ]]; then
+        echo -e "${YELLOW}════════════════════════════════════════════════════════════${RESET}"
+        echo -e "${YELLOW}${BOLD}WARNING: You installed from branch '${BRANCH}'${RESET}"
+        echo -e "${YELLOW}This is not the stable main branch. For production use:${RESET}"
+        echo -e "${YELLOW}  curl -fsSL .../main/install.sh | bash${RESET}"
+        echo -e "${YELLOW}════════════════════════════════════════════════════════════${RESET}"
+        echo ""
+    fi
 }
 
 #===============================================================================

--- a/install.sh
+++ b/install.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 #===============================================================================
-# SYNC SHUTTLE - INSTALLER
+# BUCKETCAST - INSTALLER
 #===============================================================================
-# Install sync-shuttle with: curl -fsSL https://raw.githubusercontent.com/USER/sync-shuttle/main/install.sh | bash
+# Install bucketcast with: curl -fsSL https://raw.githubusercontent.com/USER/bucketcast/main/install.sh | bash
 #
 # Options (via environment variables):
-#   SYNC_SHUTTLE_DIR    Installation directory (default: ~/.local/share/sync-shuttle)
-#   SYNC_SHUTTLE_BRANCH Git branch to install (default: main)
-#   SYNC_SHUTTLE_NO_RC  Skip shell RC file modification (default: false)
+#   BUCKETCAST_DIR    Installation directory (default: ~/.local/share/bucketcast)
+#   BUCKETCAST_BRANCH Git branch to install (default: main)
+#   BUCKETCAST_NO_RC  Skip shell RC file modification (default: false)
 #
 # Examples:
 #   curl -fsSL URL/install.sh | bash
-#   curl -fsSL URL/install.sh | SYNC_SHUTTLE_DIR=/opt/sync-shuttle bash
-#   curl -fsSL URL/install.sh | SYNC_SHUTTLE_NO_RC=1 bash
+#   curl -fsSL URL/install.sh | BUCKETCAST_DIR=/opt/bucketcast bash
+#   curl -fsSL URL/install.sh | BUCKETCAST_NO_RC=1 bash
 #===============================================================================
 
 set -o errexit
@@ -22,13 +22,13 @@ set -o pipefail
 #===============================================================================
 # CONFIGURATION
 #===============================================================================
-readonly REPO_URL="${SYNC_SHUTTLE_REPO:-https://github.com/kaurifund/bucketcast}"
+readonly REPO_URL="${BUCKETCAST_REPO:-https://github.com/kaurifund/bucketcast}"
 # TODO: Uncomment below and delete feature branch line when merging to main
-#readonly BRANCH="${SYNC_SHUTTLE_BRANCH:-main}"
-readonly BRANCH="${SYNC_SHUTTLE_BRANCH:-feature/outbox-inbox-symmetry}"
-readonly INSTALL_DIR="${SYNC_SHUTTLE_DIR:-$HOME/.local/share/sync-shuttle}"
+#readonly BRANCH="${BUCKETCAST_BRANCH:-main}"
+readonly BRANCH="${BUCKETCAST_BRANCH:-feature/outbox-inbox-symmetry}"
+readonly INSTALL_DIR="${BUCKETCAST_DIR:-$HOME/.local/share/bucketcast}"
 readonly BIN_DIR="${HOME}/.local/bin"
-readonly NO_RC="${SYNC_SHUTTLE_NO_RC:-false}"
+readonly NO_RC="${BUCKETCAST_NO_RC:-false}"
 
 # Colors
 if [[ -t 1 ]]; then
@@ -82,7 +82,7 @@ detect_shell_rc() {
 download_release() {
     local dest="$1"
     
-    info "Downloading sync-shuttle..."
+    info "Downloading bucketcast..."
     
     if command -v git &>/dev/null; then
         git clone --depth 1 --branch "$BRANCH" "$REPO_URL" "$dest" 2>/dev/null || \
@@ -108,20 +108,20 @@ install_binary() {
     mkdir -p "$BIN_DIR"
     
     # Create wrapper script
-    cat > "${BIN_DIR}/sync-shuttle" << EOF
+    cat > "${BIN_DIR}/bucketcast" << EOF
 #!/usr/bin/env bash
-exec "${INSTALL_DIR}/sync-shuttle.sh" "\$@"
+exec "${INSTALL_DIR}/bucketcast.sh" "\$@"
 EOF
     
-    chmod +x "${BIN_DIR}/sync-shuttle"
-    chmod +x "${INSTALL_DIR}/sync-shuttle.sh"
+    chmod +x "${BIN_DIR}/bucketcast"
+    chmod +x "${INSTALL_DIR}/bucketcast.sh"
     
-    success "Installed sync-shuttle to ${BIN_DIR}/sync-shuttle"
+    success "Installed bucketcast to ${BIN_DIR}/bucketcast"
 }
 
 update_shell_rc() {
     if [[ "$NO_RC" == "true" || "$NO_RC" == "1" ]]; then
-        warn "Skipping shell RC modification (SYNC_SHUTTLE_NO_RC=true)"
+        warn "Skipping shell RC modification (BUCKETCAST_NO_RC=true)"
         return
     fi
     
@@ -143,16 +143,16 @@ update_shell_rc() {
     
     # Add to rc file
     echo "" >> "$rc_file"
-    echo "# Added by sync-shuttle installer" >> "$rc_file"
+    echo "# Added by bucketcast installer" >> "$rc_file"
     echo "$path_line" >> "$rc_file"
     
     success "Added ~/.local/bin to PATH in $rc_file"
 }
 
-initialize_sync_shuttle() {
-    info "Initializing sync-shuttle..."
+initialize_bucketcast() {
+    info "Initializing bucketcast..."
 
-    "${INSTALL_DIR}/sync-shuttle.sh" init || warn "Initialization skipped (may already exist)"
+    "${INSTALL_DIR}/bucketcast.sh" init || warn "Initialization skipped (may already exist)"
 }
 
 setup_python_venv() {
@@ -186,12 +186,12 @@ setup_python_venv() {
 print_completion() {
     echo ""
     echo -e "${BOLD}════════════════════════════════════════════════════════════${RESET}"
-    echo -e "${GREEN}${BOLD}Sync Shuttle installed successfully!${RESET}"
+    echo -e "${GREEN}${BOLD}Bucketcast installed successfully!${RESET}"
     echo -e "${BOLD}════════════════════════════════════════════════════════════${RESET}"
     echo ""
     echo "Installation directory: ${INSTALL_DIR}"
-    echo "Binary location:        ${BIN_DIR}/sync-shuttle"
-    echo "Data directory:         ~/.sync-shuttle/"
+    echo "Binary location:        ${BIN_DIR}/bucketcast"
+    echo "Data directory:         ~/.bucketcast/"
     echo ""
     echo -e "${BOLD}Quick Start:${RESET}"
     echo ""
@@ -199,13 +199,13 @@ print_completion() {
     echo "     source $(detect_shell_rc)"
     echo ""
     echo "  2. Configure a server:"
-    echo "     nano ~/.sync-shuttle/config/servers.toml"
+    echo "     nano ~/.bucketcast/config/servers.toml"
     echo ""
     echo "  3. Test with dry-run:"
-    echo "     sync-shuttle push -s myserver -S ~/file.txt --dry-run"
+    echo "     bucketcast push -s myserver -S ~/file.txt --dry-run"
     echo ""
     echo "  4. (Optional) Launch the TUI:"
-    echo "     sync-shuttle tui"
+    echo "     bucketcast tui"
     echo ""
     echo -e "${BOLD}Documentation:${RESET} ${INSTALL_DIR}/README.md"
     echo ""
@@ -227,7 +227,7 @@ print_completion() {
 main() {
     echo ""
     echo -e "${BOLD}╔═══════════════════════════════════════════════════════════╗${RESET}"
-    echo -e "${BOLD}║           SYNC SHUTTLE INSTALLER                          ║${RESET}"
+    echo -e "${BOLD}║           BUCKETCAST INSTALLER                          ║${RESET}"
     echo -e "${BOLD}╚═══════════════════════════════════════════════════════════╝${RESET}"
     echo ""
     
@@ -258,7 +258,7 @@ main() {
     update_shell_rc
 
     # Initialize
-    initialize_sync_shuttle
+    initialize_bucketcast
 
     # Done
     print_completion

--- a/install.sh
+++ b/install.sh
@@ -257,6 +257,11 @@ main() {
     # Update shell RC
     update_shell_rc
 
+    # Migrate from old sync-shuttle name if needed
+    if [[ -f "${INSTALL_DIR}/migrate.sh" ]]; then
+        bash "${INSTALL_DIR}/migrate.sh" --yes
+    fi
+
     # Initialize
     initialize_bucketcast
 

--- a/lib/config_parser.py
+++ b/lib/config_parser.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Sync Shuttle - TOML Configuration Parser
+Bucketcast - TOML Configuration Parser
 
 Parses and modifies servers.toml.
 
@@ -29,7 +29,7 @@ except ImportError:
         import tomli as tomllib
     except ImportError:
         print("ERROR: TOML support not available.", file=sys.stderr)
-        print("Fix: ~/.local/share/sync-shuttle/.venv/bin/pip install tomli", file=sys.stderr)
+        print("Fix: ~/.local/share/bucketcast/.venv/bin/pip install tomli", file=sys.stderr)
         sys.exit(1)
 
 
@@ -73,8 +73,8 @@ def get_server_bash(config: dict, server_id: str) -> None:
         return str(val).replace("'", "'\\''")
 
     user = server.get('user', '')
-    # Default remote_base to user's home .sync-shuttle directory
-    default_remote_base = f"/home/{user}/.sync-shuttle" if user else ""
+    # Default remote_base to user's home .bucketcast directory
+    default_remote_base = f"/home/{user}/.bucketcast" if user else ""
     remote_base = server.get('remote_base') or default_remote_base
 
     print(f"server_name='{escape(server.get('name', server_id))}'")
@@ -141,7 +141,7 @@ def get_field(config: dict, server_id: str, field: str) -> None:
 
 def write_toml(config: dict, config_path: Path) -> None:
     """Write config back to TOML file."""
-    lines = ["# Sync Shuttle - Server Configuration", ""]
+    lines = ["# Bucketcast - Server Configuration", ""]
 
     servers = config.get("servers", {})
     for server_id, server in servers.items():
@@ -212,7 +212,7 @@ def add_server(config: dict, config_path: Path, server_id: str) -> None:
 
     write_toml(config, config_path)
     print(f"Added server: {server_id}")
-    print(f"Configure with: sync-shuttle config set {server_id} host <ip>")
+    print(f"Configure with: bucketcast config set {server_id} host <ip>")
 
 
 def remove_server(config: dict, config_path: Path, server_id: str) -> None:

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #===============================================================================
-# SYNC SHUTTLE - CORE LIBRARY
+# BUCKETCAST - CORE LIBRARY
 #===============================================================================
 # Provides core utility functions and server management.
 #
@@ -290,7 +290,7 @@ cleanup_on_exit() {
     local exit_code=$?
     
     # Release any locks
-    release_lock "sync-shuttle"
+    release_lock "bucketcast"
     
     # Clean up temp files
     if [[ -d "$TMP_DIR" ]]; then

--- a/lib/logging.sh
+++ b/lib/logging.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #===============================================================================
-# SYNC SHUTTLE - LOGGING LIBRARY
+# BUCKETCAST - LOGGING LIBRARY
 #===============================================================================
 # Provides structured logging functions for both human-readable and
 # machine-readable (JSON) output.

--- a/lib/s3.sh
+++ b/lib/s3.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #===============================================================================
-# SYNC SHUTTLE - S3 LIBRARY
+# BUCKETCAST - S3 LIBRARY
 #===============================================================================
 # Provides optional S3 integration for archival and intermediate storage.
 #
@@ -335,14 +335,14 @@ show_s3_status() {
     
     if [[ "${S3_ENABLED:-false}" != "true" ]]; then
         echo "  Status:  ${RED}Disabled${RESET}"
-        echo "  Enable in: ${CONFIG_DIR}/sync-shuttle.conf"
+        echo "  Enable in: ${CONFIG_DIR}/bucketcast.conf"
         echo ""
         return 0
     fi
     
     echo "  Status:  ${GREEN}Enabled${RESET}"
     echo "  Bucket:  ${S3_BUCKET:-not set}"
-    echo "  Prefix:  ${S3_PREFIX:-sync-shuttle-archive}"
+    echo "  Prefix:  ${S3_PREFIX:-bucketcast-archive}"
     
     if check_s3_available; then
         echo "  Access:  ${GREEN}OK${RESET}"
@@ -403,7 +403,7 @@ s3_intermediate_push() {
         log_info "Transfer marker created"
         echo ""
         echo "Transfer ID: $transfer_id"
-        echo "Remote can pull with: sync-shuttle s3-pull --transfer-id $transfer_id"
+        echo "Remote can pull with: bucketcast s3-pull --transfer-id $transfer_id"
         
         return 0
     else

--- a/lib/transfer.sh
+++ b/lib/transfer.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #===============================================================================
-# SYNC SHUTTLE - TRANSFER LIBRARY
+# BUCKETCAST - TRANSFER LIBRARY
 #===============================================================================
 # Provides file transfer functions using rsync and scp.
 #
@@ -50,7 +50,7 @@ build_rsync_options() {
     fi
     
     # Never delete (safety)
-    options+=("--ignore-existing" "--backup" "--backup-dir=.sync-shuttle-backup")
+    options+=("--ignore-existing" "--backup" "--backup-dir=.bucketcast-backup")
     
     printf '%s\n' "${options[@]}"
 }

--- a/lib/validation.sh
+++ b/lib/validation.sh
@@ -30,6 +30,12 @@ readonly OPTIONAL_TOOLS=(
     "tree"
 )
 
+# Reserved namespaces that cannot be used as server IDs
+# These are used for special directory structures (e.g., outbox/global/)
+readonly RESERVED_NAMESPACES=(
+    "global"
+)
+
 #===============================================================================
 # VALIDATE: Environment and dependencies
 #===============================================================================
@@ -195,7 +201,15 @@ validate_remote_base() {
 #===============================================================================
 validate_server_id() {
     local server_id="$1"
-    
+
+    # Check reserved namespaces
+    for reserved in "${RESERVED_NAMESPACES[@]}"; do
+        if [[ "$server_id" == "$reserved" ]]; then
+            log_error "Server ID '$server_id' is reserved and cannot be used"
+            return 1
+        fi
+    done
+
     # Check length (3-32 characters)
     if [[ ${#server_id} -lt 3 || ${#server_id} -gt 32 ]]; then
         log_error "Server ID must be 3-32 characters: $server_id"

--- a/lib/validation.sh
+++ b/lib/validation.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #===============================================================================
-# SYNC SHUTTLE - VALIDATION LIBRARY
+# BUCKETCAST - VALIDATION LIBRARY
 #===============================================================================
 # Provides validation and safety check functions to ensure operations
 # are secure and within expected parameters.
@@ -69,9 +69,9 @@ validate_environment() {
         fi
     done
     
-    # Check sync-shuttle directory exists
+    # Check bucketcast directory exists
     if [[ ! -d "$SYNC_BASE_DIR" ]]; then
-        log_error "Sync Shuttle not initialized"
+        log_error "Bucketcast not initialized"
         echo "Run '$SCRIPT_NAME init' first."
         exit 3
     fi
@@ -119,7 +119,7 @@ validate_path_within_sandbox() {
     }
     
     # Check if path starts with sandbox (must be exact match or inside sandbox/)
-    # Using trailing slash to prevent /home/user/.sync-shuttleFAKE from matching
+    # Using trailing slash to prevent /home/user/.bucketcastFAKE from matching
     if [[ "$resolved_path" != "$resolved_sandbox" && "$resolved_path" != "$resolved_sandbox"/* ]]; then
         log_error "Security violation: Path is outside sandbox"
         log_error "  Path:    $resolved_path"

--- a/migrate.sh
+++ b/migrate.sh
@@ -1,0 +1,368 @@
+#!/usr/bin/env bash
+#===============================================================================
+# migrate.sh - Migrate sync-shuttle installation to bucketcast
+#===============================================================================
+#
+# Safe, idempotent migration for users who installed under the old
+# "sync-shuttle" name. Moves data, renames configs, and updates paths.
+#
+# Usage:
+#   bash migrate.sh              # interactive (prompts before changes)
+#   bash migrate.sh --yes        # non-interactive (skip prompts)
+#   bash migrate.sh --dry-run    # preview what would change
+#
+# What it does:
+#   1. Moves ~/.sync-shuttle/ -> ~/.bucketcast/        (user data)
+#   2. Moves ~/.local/share/sync-shuttle/ -> .../bucketcast/  (install dir)
+#   3. Renames config/sync-shuttle.conf -> config/bucketcast.conf
+#   4. Updates SYNC_BASE_DIR references inside the config
+#   5. Updates remote_base paths in servers.toml
+#   6. Updates shell RC (PATH entry) if present
+#   7. Updates ~/.local/bin/ wrapper script if present
+#
+# What it does NOT do:
+#   - Delete anything (moves only, originals are gone after mv)
+#   - Touch remote servers (prints a reminder instead)
+#   - Modify file contents beyond path string replacements
+#   - Run if there is nothing to migrate
+#
+# Idempotent: safe to run multiple times. Skips steps already done.
+#
+#===============================================================================
+
+OLD_DATA_DIR="$HOME/.sync-shuttle"
+NEW_DATA_DIR="$HOME/.bucketcast"
+
+OLD_INSTALL_DIR="$HOME/.local/share/sync-shuttle"
+NEW_INSTALL_DIR="$HOME/.local/share/bucketcast"
+
+OLD_BIN="$HOME/.local/bin/sync-shuttle"
+NEW_BIN="$HOME/.local/bin/bucketcast"
+
+DRY_RUN=false
+AUTO_YES=false
+CHANGES=0
+WARNINGS=0
+
+#===============================================================================
+# OUTPUT HELPERS
+#===============================================================================
+if [[ -t 1 ]]; then
+    RED=$'\033[0;31m'
+    GREEN=$'\033[0;32m'
+    YELLOW=$'\033[0;33m'
+    BOLD=$'\033[1m'
+    RESET=$'\033[0m'
+else
+    RED="" GREEN="" YELLOW="" BOLD="" RESET=""
+fi
+
+info()    { printf "%s[INFO]%s %s\n" "$BOLD" "$RESET" "$1"; }
+ok()      { printf "%s[OK]%s %s\n" "$GREEN" "$RESET" "$1"; }
+warn()    { printf "%s[WARN]%s %s\n" "$YELLOW" "$RESET" "$1"; WARNINGS=$((WARNINGS + 1)); }
+err()     { printf "%s[ERROR]%s %s\n" "$RED" "$RESET" "$1"; }
+skip()    { printf "%s[SKIP]%s %s\n" "$BOLD" "$RESET" "$1"; }
+dry()     { printf "%s[DRY-RUN]%s Would: %s\n" "$YELLOW" "$RESET" "$1"; }
+changed() { CHANGES=$((CHANGES + 1)); }
+
+confirm() {
+    if $AUTO_YES; then return 0; fi
+    if $DRY_RUN; then return 0; fi
+    printf "\n%s%s%s [y/N] " "$BOLD" "$1" "$RESET"
+    read -r reply
+    [[ "$reply" =~ ^[Yy]$ ]]
+}
+
+#===============================================================================
+# PARSE ARGS
+#===============================================================================
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        --yes|-y)  AUTO_YES=true ;;
+        --help|-h)
+            printf "Usage: bash migrate.sh [--dry-run] [--yes] [--help]\n"
+            printf "  --dry-run  Preview changes without applying them\n"
+            printf "  --yes      Skip confirmation prompts\n"
+            exit 0
+            ;;
+        *)
+            err "Unknown argument: $arg"
+            exit 1
+            ;;
+    esac
+done
+
+#===============================================================================
+# PRE-FLIGHT: Is there anything to migrate?
+#===============================================================================
+printf "\n%s════════════════════════════════════════════════════════════%s\n" "$BOLD" "$RESET"
+printf "%s  Bucketcast Migration (sync-shuttle -> bucketcast)%s\n" "$BOLD" "$RESET"
+printf "%s════════════════════════════════════════════════════════════%s\n\n" "$BOLD" "$RESET"
+
+HAS_WORK=false
+
+if [[ -d "$OLD_DATA_DIR" ]]; then
+    info "Found old data directory: $OLD_DATA_DIR"
+    HAS_WORK=true
+fi
+if [[ -d "$OLD_INSTALL_DIR" ]]; then
+    info "Found old install directory: $OLD_INSTALL_DIR"
+    HAS_WORK=true
+fi
+if [[ -f "$OLD_BIN" ]]; then
+    info "Found old binary: $OLD_BIN"
+    HAS_WORK=true
+fi
+# Check for old references in configs that already live at new location
+if [[ -d "$NEW_DATA_DIR" ]]; then
+    if [[ -f "$NEW_DATA_DIR/config/sync-shuttle.conf" ]]; then
+        info "Found old config name at new location"
+        HAS_WORK=true
+    fi
+    if [[ -f "$NEW_DATA_DIR/config/servers.toml" ]] && grep -q '\.sync-shuttle' "$NEW_DATA_DIR/config/servers.toml" 2>/dev/null; then
+        info "Found old path references in servers.toml"
+        HAS_WORK=true
+    fi
+fi
+
+if ! $HAS_WORK; then
+    ok "Nothing to migrate. Already using bucketcast or fresh install."
+    exit 0
+fi
+
+if $DRY_RUN; then
+    info "Dry-run mode: showing what would change"
+    printf "\n"
+fi
+
+if ! $DRY_RUN && ! $AUTO_YES; then
+    printf "\nThis will rename sync-shuttle paths to bucketcast.\n"
+    printf "Your data, configs, and history will be preserved.\n"
+    if ! confirm "Proceed with migration?"; then
+        info "Aborted by user."
+        exit 0
+    fi
+    printf "\n"
+fi
+
+#===============================================================================
+# STEP 1: Move data directory ~/.sync-shuttle/ -> ~/.bucketcast/
+#===============================================================================
+info "Step 1: Data directory"
+
+if [[ -d "$OLD_DATA_DIR" ]] && [[ ! -d "$NEW_DATA_DIR" ]]; then
+    if $DRY_RUN; then
+        dry "mv $OLD_DATA_DIR -> $NEW_DATA_DIR"
+    else
+        mv "$OLD_DATA_DIR" "$NEW_DATA_DIR"
+        ok "Moved $OLD_DATA_DIR -> $NEW_DATA_DIR"
+    fi
+    changed
+elif [[ -d "$OLD_DATA_DIR" ]] && [[ -d "$NEW_DATA_DIR" ]]; then
+    warn "Both $OLD_DATA_DIR and $NEW_DATA_DIR exist"
+    warn "Skipping move to avoid data loss. Merge manually if needed."
+elif [[ ! -d "$OLD_DATA_DIR" ]]; then
+    skip "No $OLD_DATA_DIR found"
+fi
+
+#===============================================================================
+# STEP 2: Move install directory
+#===============================================================================
+info "Step 2: Install directory"
+
+if [[ -d "$OLD_INSTALL_DIR" ]] && [[ ! -d "$NEW_INSTALL_DIR" ]]; then
+    if $DRY_RUN; then
+        dry "mv $OLD_INSTALL_DIR -> $NEW_INSTALL_DIR"
+    else
+        mv "$OLD_INSTALL_DIR" "$NEW_INSTALL_DIR"
+        ok "Moved $OLD_INSTALL_DIR -> $NEW_INSTALL_DIR"
+    fi
+    changed
+elif [[ -d "$OLD_INSTALL_DIR" ]] && [[ -d "$NEW_INSTALL_DIR" ]]; then
+    warn "Both install dirs exist. Old: $OLD_INSTALL_DIR"
+    warn "Skipping. Remove the old one manually if no longer needed."
+elif [[ ! -d "$OLD_INSTALL_DIR" ]]; then
+    skip "No $OLD_INSTALL_DIR found"
+fi
+
+#===============================================================================
+# STEP 3: Rename config file sync-shuttle.conf -> bucketcast.conf
+#===============================================================================
+info "Step 3: Config file rename"
+
+# Work with whichever data dir exists now
+DATA_DIR="$NEW_DATA_DIR"
+if [[ ! -d "$DATA_DIR" ]]; then
+    DATA_DIR="$OLD_DATA_DIR"
+fi
+
+OLD_CONF="$DATA_DIR/config/sync-shuttle.conf"
+NEW_CONF="$DATA_DIR/config/bucketcast.conf"
+
+if [[ -f "$OLD_CONF" ]] && [[ ! -f "$NEW_CONF" ]]; then
+    if $DRY_RUN; then
+        dry "mv $OLD_CONF -> $NEW_CONF"
+    else
+        mv "$OLD_CONF" "$NEW_CONF"
+        ok "Renamed sync-shuttle.conf -> bucketcast.conf"
+    fi
+    changed
+elif [[ -f "$OLD_CONF" ]] && [[ -f "$NEW_CONF" ]]; then
+    warn "Both config files exist. Old kept at: $OLD_CONF"
+elif [[ ! -f "$OLD_CONF" ]]; then
+    skip "No sync-shuttle.conf to rename"
+fi
+
+#===============================================================================
+# STEP 4: Update SYNC_BASE_DIR inside config
+#===============================================================================
+info "Step 4: Update paths in config"
+
+# Check both old and new name (old may still exist in dry-run or if rename was skipped)
+CONF_FILE="$NEW_CONF"
+if [[ ! -f "$CONF_FILE" ]]; then
+    CONF_FILE="$OLD_CONF"
+fi
+
+if [[ -f "$CONF_FILE" ]] && grep -q '\.sync-shuttle' "$CONF_FILE" 2>/dev/null; then
+    if $DRY_RUN; then
+        dry "Replace .sync-shuttle with .bucketcast in $CONF_FILE"
+        grep '\.sync-shuttle' "$CONF_FILE" | while read -r line; do
+            printf "       %s\n" "$line"
+        done
+    else
+        sed -i 's|\.sync-shuttle|.bucketcast|g' "$CONF_FILE"
+        ok "Updated paths in $(basename "$CONF_FILE")"
+    fi
+    changed
+else
+    skip "No old paths in config"
+fi
+
+#===============================================================================
+# STEP 5: Update remote_base in servers.toml
+#===============================================================================
+info "Step 5: Update remote_base in servers.toml"
+
+SERVERS_FILE="$DATA_DIR/config/servers.toml"
+
+if [[ -f "$SERVERS_FILE" ]] && grep -q '\.sync-shuttle' "$SERVERS_FILE" 2>/dev/null; then
+    if $DRY_RUN; then
+        dry "Replace .sync-shuttle with .bucketcast in servers.toml"
+        grep '\.sync-shuttle' "$SERVERS_FILE" | while read -r line; do
+            printf "       %s\n" "$line"
+        done
+    else
+        sed -i 's|\.sync-shuttle|.bucketcast|g' "$SERVERS_FILE"
+        ok "Updated remote_base paths in servers.toml"
+    fi
+    changed
+    warn "Remote servers still have ~/.sync-shuttle/ directories"
+    warn "Run this script (or mv ~/.sync-shuttle ~/.bucketcast) on each remote host"
+else
+    skip "No old paths in servers.toml"
+fi
+
+#===============================================================================
+# STEP 6: Update shell RC files
+#===============================================================================
+info "Step 6: Shell RC files"
+
+RC_UPDATED=false
+for rc_file in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.config/fish/config.fish" "$HOME/.profile" "$HOME/.bash_profile"; do
+    if [[ -f "$rc_file" ]] && grep -q 'sync-shuttle' "$rc_file" 2>/dev/null; then
+        if $DRY_RUN; then
+            dry "Replace sync-shuttle references in $rc_file"
+            grep 'sync-shuttle' "$rc_file" | while read -r line; do
+                printf "       %s\n" "$line"
+            done
+        else
+            sed -i 's|sync-shuttle|bucketcast|g' "$rc_file"
+            ok "Updated $rc_file"
+        fi
+        RC_UPDATED=true
+        changed
+    fi
+done
+
+if ! $RC_UPDATED; then
+    skip "No sync-shuttle references in shell RC files"
+fi
+
+#===============================================================================
+# STEP 7: Update or replace bin wrapper
+#===============================================================================
+info "Step 7: Binary wrapper"
+
+if [[ -f "$OLD_BIN" ]] && [[ ! -f "$NEW_BIN" ]]; then
+    if $DRY_RUN; then
+        dry "mv $OLD_BIN -> $NEW_BIN"
+    else
+        mv "$OLD_BIN" "$NEW_BIN"
+        # Update the wrapper content to point to new install dir
+        if grep -q 'sync-shuttle' "$NEW_BIN" 2>/dev/null; then
+            sed -i 's|sync-shuttle|bucketcast|g' "$NEW_BIN"
+        fi
+        ok "Moved and updated bin wrapper"
+    fi
+    changed
+elif [[ -f "$OLD_BIN" ]] && [[ -f "$NEW_BIN" ]]; then
+    warn "Both $OLD_BIN and $NEW_BIN exist"
+    warn "Remove $OLD_BIN manually if it is no longer needed"
+elif [[ ! -f "$OLD_BIN" ]]; then
+    skip "No old binary wrapper found"
+fi
+
+#===============================================================================
+# STEP 8: Handle .syncshuttlerc -> .bucketcastrc
+#===============================================================================
+info "Step 8: User RC file"
+
+OLD_RC="$HOME/.syncshuttlerc"
+NEW_RC="$HOME/.bucketcastrc"
+
+if [[ -f "$OLD_RC" ]] && [[ ! -f "$NEW_RC" ]]; then
+    if $DRY_RUN; then
+        dry "mv $OLD_RC -> $NEW_RC"
+    else
+        mv "$OLD_RC" "$NEW_RC"
+        if grep -q 'sync-shuttle\|SYNC_SHUTTLE' "$NEW_RC" 2>/dev/null; then
+            sed -i 's|sync-shuttle|bucketcast|g; s|SYNC_SHUTTLE|BUCKETCAST|g; s|sync_shuttle|bucketcast|g' "$NEW_RC"
+        fi
+        ok "Moved and updated .syncshuttlerc -> .bucketcastrc"
+    fi
+    changed
+elif [[ -f "$OLD_RC" ]] && [[ -f "$NEW_RC" ]]; then
+    warn "Both $OLD_RC and $NEW_RC exist. Old one left in place."
+elif [[ ! -f "$OLD_RC" ]]; then
+    skip "No .syncshuttlerc found"
+fi
+
+#===============================================================================
+# SUMMARY
+#===============================================================================
+printf "\n%s════════════════════════════════════════════════════════════%s\n" "$BOLD" "$RESET"
+
+if $DRY_RUN; then
+    printf "%s  Dry-run complete: %d change(s) would be made%s\n" "$BOLD" "$CHANGES" "$RESET"
+    printf "%s  Run without --dry-run to apply.%s\n" "$BOLD" "$RESET"
+elif [[ "$CHANGES" -gt 0 ]]; then
+    printf "%s%s  Migration complete: %d change(s) applied%s\n" "$BOLD" "$GREEN" "$CHANGES" "$RESET"
+    if [[ "$WARNINGS" -gt 0 ]]; then
+        printf "%s  %d warning(s) - review output above%s\n" "$YELLOW" "$WARNINGS" "$RESET"
+    fi
+    printf "\n  Next steps:\n"
+    printf "    1. Restart your shell: exec \$SHELL\n"
+    printf "    2. Verify: bucketcast --version\n"
+    printf "    3. Check config: bucketcast list servers\n"
+    if [[ "$WARNINGS" -gt 0 ]]; then
+        printf "    4. Review warnings above\n"
+    fi
+else
+    printf "%s  No changes needed%s\n" "$GREEN" "$RESET"
+fi
+
+printf "%s════════════════════════════════════════════════════════════%s\n\n" "$BOLD" "$RESET"
+
+exit 0

--- a/sync-shuttle.sh
+++ b/sync-shuttle.sh
@@ -344,6 +344,9 @@ FORCE="false"
 VERBOSE="false"
 QUIET="false"
 S3_ARCHIVE="false"
+GLOBAL_MODE="false"
+LIST_MODE="false"
+REMOVE_MODE="false"
 OPERATION_UUID=""
 CONFIG_ARGS=()
 
@@ -485,7 +488,7 @@ parse_arguments() {
 
     # First argument should be the command
     case "${1:-}" in
-        init|push|pull|list|status|config|tui|help|--help|-h)
+        init|push|pull|list|status|config|share|tui|help|--help|-h)
             ACTION="${1}"
             shift
             ;;
@@ -553,6 +556,18 @@ parse_arguments() {
                 ;;
             --s3-archive)
                 S3_ARCHIVE="true"
+                shift
+                ;;
+            --global)
+                GLOBAL_MODE="true"
+                shift
+                ;;
+            --list)
+                LIST_MODE="true"
+                shift
+                ;;
+            --remove)
+                REMOVE_MODE="true"
                 shift
                 ;;
             servers|files)
@@ -733,6 +748,9 @@ dispatch_action() {
             ;;
         config)
             action_config
+            ;;
+        share)
+            action_share
             ;;
         tui)
             action_tui
@@ -1058,6 +1076,141 @@ action_pull() {
         "$timestamp_start" "$timestamp_end" "SUCCESS"
     
     log_success "Pull operation completed [${OPERATION_UUID}]"
+}
+
+#===============================================================================
+# ACTION: SHARE
+# Manage files in the outbox for sharing with remote servers
+#===============================================================================
+action_share() {
+    local share_dir
+
+    # Handle --list without server/global (list all)
+    if [[ "${LIST_MODE:-false}" == "true" && -z "$SERVER_ID" && "${GLOBAL_MODE:-false}" != "true" ]]; then
+        echo ""
+        echo "${BOLD}All shared files${RESET}"
+        echo "─────────────────────────────────────────────────────────"
+
+        if [[ -d "$OUTBOX_DIR" ]]; then
+            local count=0
+            while IFS= read -r -d '' file; do
+                local rel_path="${file#$OUTBOX_DIR/}"
+                echo "  $rel_path"
+                ((count++)) || true
+            done < <(find "$OUTBOX_DIR" -type f -print0 2>/dev/null)
+
+            if [[ $count -eq 0 ]]; then
+                echo "  (no files)"
+            fi
+            echo ""
+            echo "Total: $count file(s)"
+        else
+            echo "  (no files)"
+        fi
+        return 0
+    fi
+
+    # Determine target directory
+    if [[ -n "$SERVER_ID" ]]; then
+        # Server-specific share
+        share_dir="${OUTBOX_DIR}/${SERVER_ID}"
+    elif [[ "${GLOBAL_MODE:-false}" == "true" ]]; then
+        # Global share (available to all servers)
+        share_dir="${OUTBOX_DIR}/global"
+    else
+        log_error "Must specify -s <server> or --global"
+        echo "Usage:"
+        echo "  $SCRIPT_NAME share -s <server> <file>      # Share with specific server"
+        echo "  $SCRIPT_NAME share --global <file>         # Share with all servers"
+        echo "  $SCRIPT_NAME share --list                  # List all shared files"
+        echo "  $SCRIPT_NAME share -s <server> --list      # List server-specific shares"
+        echo "  $SCRIPT_NAME share --global --list         # List global shares"
+        echo "  $SCRIPT_NAME share -s <server> --remove <file>  # Remove from share"
+        exit 2
+    fi
+
+    # List mode
+    if [[ "${LIST_MODE:-false}" == "true" ]]; then
+        echo ""
+        if [[ -n "$SERVER_ID" ]]; then
+            echo "${BOLD}Shared with: ${SERVER_ID}${RESET}"
+        elif [[ "${GLOBAL_MODE:-false}" == "true" ]]; then
+            echo "${BOLD}Global shares (all servers)${RESET}"
+        else
+            # List all shares
+            echo "${BOLD}All shared files${RESET}"
+            share_dir="${OUTBOX_DIR}"
+        fi
+        echo "─────────────────────────────────────────────────────────"
+
+        if [[ -d "$share_dir" ]]; then
+            local count=0
+            while IFS= read -r -d '' file; do
+                local rel_path="${file#$OUTBOX_DIR/}"
+                echo "  $rel_path"
+                ((count++)) || true
+            done < <(find "$share_dir" -type f -print0 2>/dev/null)
+
+            if [[ $count -eq 0 ]]; then
+                echo "  (no files)"
+            fi
+            echo ""
+            echo "Total: $count file(s)"
+        else
+            echo "  (no files)"
+        fi
+        return 0
+    fi
+
+    # Remove mode
+    if [[ "${REMOVE_MODE:-false}" == "true" ]]; then
+        if [[ -z "$SOURCE_PATH" ]]; then
+            log_error "File to remove is required"
+            echo "Usage: $SCRIPT_NAME share -s <server> --remove <file>"
+            exit 2
+        fi
+
+        local file_to_remove="${share_dir}/$(basename "$SOURCE_PATH")"
+        if [[ -f "$file_to_remove" ]]; then
+            rm -f "$file_to_remove"
+            log_info "Removed: ${file_to_remove#$OUTBOX_DIR/}"
+        else
+            log_warn "File not found: ${file_to_remove#$OUTBOX_DIR/}"
+        fi
+        return 0
+    fi
+
+    # Add mode (default)
+    if [[ -z "$SOURCE_PATH" ]]; then
+        log_error "Source file/directory is required"
+        echo "Usage: $SCRIPT_NAME share -s <server> <file>"
+        exit 2
+    fi
+
+    # Validate source exists
+    if [[ ! -e "$SOURCE_PATH" ]]; then
+        log_error "Source does not exist: $SOURCE_PATH"
+        exit 5
+    fi
+
+    # Create share directory
+    mkdir -p "$share_dir"
+
+    # Copy file to share directory
+    if cp -r "$SOURCE_PATH" "$share_dir/"; then
+        local dest_name
+        dest_name=$(basename "$SOURCE_PATH")
+        log_success "Shared: ${share_dir#$OUTBOX_DIR/}/${dest_name}"
+
+        if [[ -n "$SERVER_ID" ]]; then
+            log_info "Server '$SERVER_ID' can pull this file"
+        else
+            log_info "All servers can pull this file"
+        fi
+    else
+        log_error "Failed to copy file to share directory"
+        exit 1
+    fi
 }
 
 #===============================================================================

--- a/sync-shuttle.sh
+++ b/sync-shuttle.sh
@@ -426,6 +426,7 @@ ${BOLD}COMMANDS:${RESET}
     init                    Initialize sync-shuttle directory structure
     push                    Push files TO a remote server
     pull                    Pull files FROM a remote server
+    share                   Share files via outbox (for others to pull)
     list <servers|files>    List servers or files in a server's directory
     status                  Show sync status and recent operations
     config <subcommand>     Manage server configuration
@@ -445,6 +446,9 @@ ${BOLD}OPTIONS:${RESET}
     -v, --verbose           Verbose output
     -q, --quiet             Minimal output
     --s3-archive            Archive to S3 after successful sync
+    --global                Share with all servers (share command)
+    --list                  List shared files (share command)
+    --remove                Remove from share (share command)
     -h, --help              Show this help message
     -V, --version           Show version
 
@@ -462,6 +466,15 @@ ${BOLD}EXAMPLES:${RESET}
     # Pull from a server
     $SCRIPT_NAME pull -s myserver --dry-run
     $SCRIPT_NAME pull -s myserver
+
+    # Share a file globally (all servers can pull)
+    $SCRIPT_NAME share --global -S ~/shared-doc.pdf
+
+    # Share with a specific server
+    $SCRIPT_NAME share -s myserver -S ~/for-them.txt
+
+    # List shared files
+    $SCRIPT_NAME share --list
 
 ${BOLD}SAFETY:${RESET}
     • All operations are sandboxed to ~/.sync-shuttle/

--- a/tests/e2e/test_scenarios.sh
+++ b/tests/e2e/test_scenarios.sh
@@ -3,22 +3,22 @@
 # END-TO-END TESTS - USER SCENARIOS
 #===============================================================================
 # Tests that verify complete user workflows from start to finish.
-# These tests run the actual sync-shuttle.sh script.
+# These tests run the actual bucketcast.sh script.
 #===============================================================================
 
-readonly SYNC_SHUTTLE="${PROJECT_ROOT}/sync-shuttle.sh"
+readonly BUCKETCAST="${PROJECT_ROOT}/bucketcast.sh"
 
 #===============================================================================
 # SETUP
 #===============================================================================
 setup_e2e() {
     export HOME="${TEST_DIR}/home"
-    export SYNC_BASE_DIR="${HOME}/.sync-shuttle"
+    export SYNC_BASE_DIR="${HOME}/.bucketcast"
     
     mkdir -p "$HOME"
     
     # Make script executable
-    chmod +x "$SYNC_SHUTTLE"
+    chmod +x "$BUCKETCAST"
 }
 
 #===============================================================================
@@ -29,7 +29,7 @@ test_e2e_init_creates_structure() {
     setup_e2e
     
     # Run init
-    "$SYNC_SHUTTLE" init &>/dev/null
+    "$BUCKETCAST" init &>/dev/null
     
     # Verify structure
     assert_dir_exists "$SYNC_BASE_DIR"
@@ -46,10 +46,10 @@ test_e2e_init_creates_config_files() {
     setup_e2e
     
     # Run init
-    "$SYNC_SHUTTLE" init &>/dev/null
+    "$BUCKETCAST" init &>/dev/null
     
     # Verify config files
-    assert_file_exists "${SYNC_BASE_DIR}/config/sync-shuttle.conf"
+    assert_file_exists "${SYNC_BASE_DIR}/config/bucketcast.conf"
     assert_file_exists "${SYNC_BASE_DIR}/config/servers.toml"
 }
 
@@ -57,7 +57,7 @@ test_e2e_init_creates_log_files() {
     setup_e2e
     
     # Run init
-    "$SYNC_SHUTTLE" init &>/dev/null
+    "$BUCKETCAST" init &>/dev/null
     
     # Verify log files
     assert_file_exists "${SYNC_BASE_DIR}/logs/sync.log"
@@ -68,8 +68,8 @@ test_e2e_init_is_idempotent() {
     setup_e2e
     
     # Run init twice
-    "$SYNC_SHUTTLE" init &>/dev/null
-    "$SYNC_SHUTTLE" init &>/dev/null
+    "$BUCKETCAST" init &>/dev/null
+    "$BUCKETCAST" init &>/dev/null
     
     # Should still work without errors
     assert_dir_exists "$SYNC_BASE_DIR"
@@ -83,7 +83,7 @@ test_e2e_help_shows_usage() {
     setup_e2e
     
     local output
-    output=$("$SYNC_SHUTTLE" --help 2>&1)
+    output=$("$BUCKETCAST" --help 2>&1)
     
     assert_contains "$output" "USAGE" "Help should show usage"
     assert_contains "$output" "COMMANDS" "Help should show commands"
@@ -94,9 +94,9 @@ test_e2e_version_shows_version() {
     setup_e2e
     
     local output
-    output=$("$SYNC_SHUTTLE" --version 2>&1)
+    output=$("$BUCKETCAST" --version 2>&1)
     
-    assert_contains "$output" "sync-shuttle" "Version should show name"
+    assert_contains "$output" "bucketcast" "Version should show name"
     assert_contains "$output" "version" "Version should show version word"
 }
 
@@ -108,11 +108,11 @@ test_e2e_list_servers_works() {
     setup_e2e
     
     # Init first
-    "$SYNC_SHUTTLE" init &>/dev/null
+    "$BUCKETCAST" init &>/dev/null
     
     # List servers
     local output
-    output=$("$SYNC_SHUTTLE" list servers 2>&1)
+    output=$("$BUCKETCAST" list servers 2>&1)
     
     # Should output something (even if empty)
     # At minimum should show header
@@ -123,10 +123,10 @@ test_e2e_list_files_requires_server() {
     setup_e2e
     
     # Init first
-    "$SYNC_SHUTTLE" init &>/dev/null
+    "$BUCKETCAST" init &>/dev/null
     
     # List files without server should fail
-    if "$SYNC_SHUTTLE" list files 2>/dev/null; then
+    if "$BUCKETCAST" list files 2>/dev/null; then
         echo "Should require server ID for list files"
         return 1
     fi
@@ -140,11 +140,11 @@ test_e2e_status_shows_info() {
     setup_e2e
     
     # Init first
-    "$SYNC_SHUTTLE" init &>/dev/null
+    "$BUCKETCAST" init &>/dev/null
     
     # Check status
     local output
-    output=$("$SYNC_SHUTTLE" status 2>&1)
+    output=$("$BUCKETCAST" status 2>&1)
     
     assert_contains "$output" "Status" "Should show status header"
 }
@@ -156,10 +156,10 @@ test_e2e_status_shows_info() {
 test_e2e_push_requires_server() {
     setup_e2e
     
-    "$SYNC_SHUTTLE" init &>/dev/null
+    "$BUCKETCAST" init &>/dev/null
     
     # Push without server should fail
-    if "$SYNC_SHUTTLE" push 2>/dev/null; then
+    if "$BUCKETCAST" push 2>/dev/null; then
         echo "Should require server for push"
         return 1
     fi
@@ -168,7 +168,7 @@ test_e2e_push_requires_server() {
 test_e2e_push_requires_source() {
     setup_e2e
     
-    "$SYNC_SHUTTLE" init &>/dev/null
+    "$BUCKETCAST" init &>/dev/null
     
     # Add a test server
     cat > "${SYNC_BASE_DIR}/config/servers.toml" << 'EOF'
@@ -184,7 +184,7 @@ declare -A server_test=(
 EOF
     
     # Push without source should fail
-    if "$SYNC_SHUTTLE" push --server test 2>/dev/null; then
+    if "$BUCKETCAST" push --server test 2>/dev/null; then
         echo "Should require source for push"
         return 1
     fi
@@ -193,7 +193,7 @@ EOF
 test_e2e_push_validates_source_exists() {
     setup_e2e
     
-    "$SYNC_SHUTTLE" init &>/dev/null
+    "$BUCKETCAST" init &>/dev/null
     
     # Add a test server
     cat > "${SYNC_BASE_DIR}/config/servers.toml" << 'EOF'
@@ -209,7 +209,7 @@ declare -A server_test=(
 EOF
     
     # Push with non-existent source should fail
-    if "$SYNC_SHUTTLE" push --server test --source /nonexistent/path 2>/dev/null; then
+    if "$BUCKETCAST" push --server test --source /nonexistent/path 2>/dev/null; then
         echo "Should validate source exists"
         return 1
     fi
@@ -218,7 +218,7 @@ EOF
 test_e2e_push_dry_run_makes_no_changes() {
     setup_e2e
     
-    "$SYNC_SHUTTLE" init &>/dev/null
+    "$BUCKETCAST" init &>/dev/null
     
     # Create test file
     local test_file="${TEST_DIR}/dry_run_test.txt"
@@ -231,7 +231,7 @@ declare -A server_test=(
     [host]="localhost"
     [port]="22"
     [user]="nobody"
-    [remote_base]="/tmp/sync-shuttle-test"
+    [remote_base]="/tmp/bucketcast-test"
     [enabled]="true"
     [s3_backup]="false"
 )
@@ -239,7 +239,7 @@ EOF
     
     # Dry run (will fail SSH but should show dry-run message)
     local output
-    output=$("$SYNC_SHUTTLE" push --server test --source "$test_file" --dry-run 2>&1) || true
+    output=$("$BUCKETCAST" push --server test --source "$test_file" --dry-run 2>&1) || true
     
     assert_contains "$output" "DRY" "Should indicate dry-run mode"
 }
@@ -251,10 +251,10 @@ EOF
 test_e2e_pull_requires_server() {
     setup_e2e
     
-    "$SYNC_SHUTTLE" init &>/dev/null
+    "$BUCKETCAST" init &>/dev/null
     
     # Pull without server should fail
-    if "$SYNC_SHUTTLE" pull 2>/dev/null; then
+    if "$BUCKETCAST" pull 2>/dev/null; then
         echo "Should require server for pull"
         return 1
     fi
@@ -267,7 +267,7 @@ test_e2e_pull_requires_server() {
 test_e2e_unknown_command_fails() {
     setup_e2e
     
-    if "$SYNC_SHUTTLE" unknowncommand 2>/dev/null; then
+    if "$BUCKETCAST" unknowncommand 2>/dev/null; then
         echo "Should fail for unknown command"
         return 1
     fi
@@ -276,7 +276,7 @@ test_e2e_unknown_command_fails() {
 test_e2e_invalid_option_fails() {
     setup_e2e
     
-    if "$SYNC_SHUTTLE" init --invalid-option 2>/dev/null; then
+    if "$BUCKETCAST" init --invalid-option 2>/dev/null; then
         echo "Should fail for invalid option"
         return 1
     fi
@@ -290,7 +290,7 @@ test_e2e_success_returns_zero() {
     setup_e2e
     
     local exit_code
-    "$SYNC_SHUTTLE" --help &>/dev/null
+    "$BUCKETCAST" --help &>/dev/null
     exit_code=$?
     
     assert_equals "$exit_code" "0" "Help should return exit code 0"
@@ -300,7 +300,7 @@ test_e2e_error_returns_nonzero() {
     setup_e2e
     
     local exit_code
-    "$SYNC_SHUTTLE" invalid 2>/dev/null || exit_code=$?
+    "$BUCKETCAST" invalid 2>/dev/null || exit_code=$?
     
     assert_not_equals "${exit_code:-0}" "0" "Error should return non-zero exit code"
 }

--- a/tests/fixtures/sample_config.conf
+++ b/tests/fixtures/sample_config.conf
@@ -5,7 +5,7 @@
 # DO NOT use in production.
 #===============================================================================
 
-SYNC_BASE_DIR="${TEST_DIR}/sync-shuttle"
+SYNC_BASE_DIR="${TEST_DIR}/bucketcast"
 DEFAULT_SSH_PORT=22
 LOG_LEVEL="DEBUG"
 S3_ENABLED="false"

--- a/tests/fixtures/sample_servers.conf
+++ b/tests/fixtures/sample_servers.conf
@@ -10,7 +10,7 @@ declare -A server_fixture_dev=(
     [host]="dev.fixture.local"
     [port]="22"
     [user]="testdev"
-    [remote_base]="/home/testdev/.sync-shuttle"
+    [remote_base]="/home/testdev/.bucketcast"
     [enabled]="true"
     [s3_backup]="false"
 )
@@ -20,7 +20,7 @@ declare -A server_fixture_prod=(
     [host]="prod.fixture.local"
     [port]="2222"
     [user]="testprod"
-    [remote_base]="/var/sync-shuttle"
+    [remote_base]="/var/bucketcast"
     [enabled]="true"
     [s3_backup]="true"
 )

--- a/tests/helpers/fixtures.sh
+++ b/tests/helpers/fixtures.sh
@@ -38,8 +38,8 @@ create_test_config() {
     local config_dir="${CONFIG_DIR:-$TEST_DIR/config}"
     mkdir -p "$config_dir"
     
-    cat > "${config_dir}/sync-shuttle.conf" << 'EOF'
-SYNC_BASE_DIR="${SYNC_BASE_DIR:-$HOME/.sync-shuttle}"
+    cat > "${config_dir}/bucketcast.conf" << 'EOF'
+SYNC_BASE_DIR="${SYNC_BASE_DIR:-$HOME/.bucketcast}"
 DEFAULT_SSH_PORT=22
 LOG_LEVEL="ERROR"
 S3_ENABLED="false"
@@ -47,7 +47,7 @@ ARCHIVE_RETENTION_DAYS=30
 MAX_TRANSFER_SIZE="10G"
 EOF
     
-    echo "${config_dir}/sync-shuttle.conf"
+    echo "${config_dir}/bucketcast.conf"
 }
 
 # Create a test server configuration
@@ -62,7 +62,7 @@ declare -A server_${server_id}=(
     [host]="localhost"
     [port]="22"
     [user]="testuser"
-    [remote_base]="/tmp/sync-shuttle-test"
+    [remote_base]="/tmp/bucketcast-test"
     [enabled]="true"
     [s3_backup]="false"
 )
@@ -102,7 +102,7 @@ declare -A server_dev=(
     [host]="dev.example.com"
     [port]="22"
     [user]="developer"
-    [remote_base]="/home/developer/.sync-shuttle"
+    [remote_base]="/home/developer/.bucketcast"
     [enabled]="true"
     [s3_backup]="false"
 )
@@ -112,7 +112,7 @@ declare -A server_prod=(
     [host]="prod.example.com"
     [port]="2222"
     [user]="deploy"
-    [remote_base]="/var/sync-shuttle"
+    [remote_base]="/var/bucketcast"
     [enabled]="true"
     [s3_backup]="true"
 )
@@ -163,9 +163,9 @@ create_test_logs() {
     echo "$logs_dir"
 }
 
-# Initialize complete test sync-shuttle directory
-init_test_sync_shuttle() {
-    local base="${SYNC_BASE_DIR:-$TEST_DIR/sync-shuttle}"
+# Initialize complete test bucketcast directory
+init_test_bucketcast() {
+    local base="${SYNC_BASE_DIR:-$TEST_DIR/bucketcast}"
     
     mkdir -p "$base"/{config,remote,local/{inbox,outbox},logs,archive,tmp}
     

--- a/tests/helpers/test_helpers.sh
+++ b/tests/helpers/test_helpers.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #===============================================================================
-# SYNC SHUTTLE - TEST HELPERS
+# BUCKETCAST - TEST HELPERS
 #===============================================================================
 # Common utilities and fixtures for all test types.
 # Source this file at the start of any test script.
@@ -24,7 +24,7 @@ set -o pipefail
 #===============================================================================
 readonly TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly PROJECT_ROOT="$(cd "${TEST_DIR}/.." && pwd)"
-readonly SYNC_SHUTTLE="${PROJECT_ROOT}/sync-shuttle.sh"
+readonly BUCKETCAST="${PROJECT_ROOT}/bucketcast.sh"
 
 # Test isolation - each test gets its own temp directory
 TEST_TMP=""
@@ -61,13 +61,13 @@ fi
 # Call at start of test file
 setup_test_environment() {
     # Create isolated temp directory
-    TEST_TMP=$(mktemp -d -t sync-shuttle-test.XXXXXX)
+    TEST_TMP=$(mktemp -d -t bucketcast-test.XXXXXX)
     TEST_HOME="${TEST_TMP}/home"
-    TEST_SYNC_BASE="${TEST_HOME}/.sync-shuttle"
+    TEST_SYNC_BASE="${TEST_HOME}/.bucketcast"
     
     mkdir -p "$TEST_HOME"
     
-    # Export for sync-shuttle to use
+    # Export for bucketcast to use
     export HOME="$TEST_HOME"
     export SYNC_BASE_DIR="$TEST_SYNC_BASE"
     
@@ -93,9 +93,9 @@ cleanup_test_environment() {
     return $exit_code
 }
 
-# Initialize sync-shuttle in test environment
-init_sync_shuttle() {
-    "$SYNC_SHUTTLE" init >/dev/null 2>&1
+# Initialize bucketcast in test environment
+init_bucketcast() {
+    "$BUCKETCAST" init >/dev/null 2>&1
 }
 
 #===============================================================================
@@ -331,7 +331,7 @@ declare -A server_${server_id}=(
     [host]="localhost"
     [port]="22"
     [user]="testuser"
-    [remote_base]="/tmp/sync-shuttle-remote"
+    [remote_base]="/tmp/bucketcast-remote"
     [enabled]="true"
     [s3_backup]="false"
 )

--- a/tests/integration/test_config.sh
+++ b/tests/integration/test_config.sh
@@ -46,13 +46,13 @@ test_init_preserves_existing_configs() {
     mkdir -p "${SYNC_BASE_DIR}/config"
     
     # Create existing config
-    echo "CUSTOM_SETTING=true" > "${SYNC_BASE_DIR}/config/sync-shuttle.conf"
+    echo "CUSTOM_SETTING=true" > "${SYNC_BASE_DIR}/config/bucketcast.conf"
     
     # Run init again
     mkdir -p "$SYNC_BASE_DIR"/{config,remote,local/{inbox,outbox},logs,archive,tmp}
     
     # Original config should be preserved
-    assert_file_contains "${SYNC_BASE_DIR}/config/sync-shuttle.conf" "CUSTOM_SETTING=true"
+    assert_file_contains "${SYNC_BASE_DIR}/config/bucketcast.conf" "CUSTOM_SETTING=true"
 }
 
 #===============================================================================
@@ -65,14 +65,14 @@ test_config_loading_reads_main_config() {
     mkdir -p "$CONFIG_DIR"
     
     # Create config
-    cat > "${CONFIG_DIR}/sync-shuttle.conf" << 'EOF'
+    cat > "${CONFIG_DIR}/bucketcast.conf" << 'EOF'
 LOG_LEVEL="DEBUG"
 MAX_TRANSFER_SIZE="5G"
 S3_ENABLED="true"
 EOF
     
     # Source config
-    source "${CONFIG_DIR}/sync-shuttle.conf"
+    source "${CONFIG_DIR}/bucketcast.conf"
     
     assert_equals "$LOG_LEVEL" "DEBUG"
     assert_equals "$MAX_TRANSFER_SIZE" "5G"
@@ -113,7 +113,7 @@ test_config_loading_handles_missing_config() {
     
     # No config file exists
     # Should not fail (use defaults)
-    if [[ ! -f "${CONFIG_DIR}/sync-shuttle.conf" ]]; then
+    if [[ ! -f "${CONFIG_DIR}/bucketcast.conf" ]]; then
         # This is expected - defaults should apply
         :
     fi

--- a/tests/integration/test_transfer.sh
+++ b/tests/integration/test_transfer.sh
@@ -16,7 +16,7 @@ source "${TEST_DIR}/lib/transfer.sh" 2>/dev/null || source "${PROJECT_ROOT}/lib/
 # SETUP
 #===============================================================================
 setup_transfer_test() {
-    export SYNC_BASE_DIR="${TEST_DIR}/sync-shuttle"
+    export SYNC_BASE_DIR="${TEST_DIR}/bucketcast"
     export REMOTE_DIR="${SYNC_BASE_DIR}/remote"
     export LOCAL_DIR="${SYNC_BASE_DIR}/local"
     export INBOX_DIR="${LOCAL_DIR}/inbox"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #===============================================================================
-# SYNC SHUTTLE - TEST RUNNER
+# BUCKETCAST - TEST RUNNER
 #===============================================================================
 # Main entry point for running all tests.
 #
@@ -32,7 +32,7 @@ set -o pipefail
 #===============================================================================
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
-readonly TEST_TMP_BASE="/tmp/sync-shuttle-tests"
+readonly TEST_TMP_BASE="/tmp/bucketcast-tests"
 readonly TEST_TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
 readonly TEST_TMP_DIR="${TEST_TMP_BASE}/${TEST_TIMESTAMP}"
 
@@ -72,14 +72,14 @@ source "${SCRIPT_DIR}/helpers/mocks.sh"
 # Setup test environment (called before each test file)
 setup_test_env() {
     export TEST_DIR="${TEST_TMP_DIR}/$$_${RANDOM}"
-    export SYNC_BASE_DIR="${TEST_DIR}/sync-shuttle"
+    export SYNC_BASE_DIR="${TEST_DIR}/bucketcast"
     export HOME="${TEST_DIR}/home"
     
     mkdir -p "$TEST_DIR" "$SYNC_BASE_DIR" "$HOME"
     
     # Copy project files to test environment
     cp -r "${PROJECT_ROOT}/lib" "${TEST_DIR}/"
-    cp "${PROJECT_ROOT}/sync-shuttle.sh" "${TEST_DIR}/"
+    cp "${PROJECT_ROOT}/bucketcast.sh" "${TEST_DIR}/"
     
     # Source libraries for unit testing
     export SCRIPT_DIR="${TEST_DIR}"
@@ -259,7 +259,7 @@ main() {
     
     echo ""
     echo -e "${BOLD}╔═══════════════════════════════════════════════════════════╗${RESET}"
-    echo -e "${BOLD}║           SYNC SHUTTLE TEST SUITE                         ║${RESET}"
+    echo -e "${BOLD}║           BUCKETCAST TEST SUITE                         ║${RESET}"
     echo -e "${BOLD}╚═══════════════════════════════════════════════════════════╝${RESET}"
     
     # Create temp directory

--- a/tickets/20260105_outbox_inbox_symmetry/IMPLEMENTATION_PLAN.md
+++ b/tickets/20260105_outbox_inbox_symmetry/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,461 @@
+# Implementation Plan: Inbox/Outbox Symmetry
+
+**Ticket:** 20260105_outbox_inbox_symmetry
+**Status:** Draft - Awaiting Approval
+
+---
+
+## Git Strategy
+
+### Current Open PRs
+
+| PR | Branch | Description | Files Touched |
+|----|--------|-------------|---------------|
+| #2 | feature/file-discovery | File discovery commands | sync-shuttle.sh, tui/, docs/ |
+| #3 | feature/push-positional-args | Positional args for push | sync-shuttle.sh, lib/transfer.sh |
+
+PR #3 is stacked on PR #2.
+
+### Overlap Analysis
+
+This ticket touches:
+- `sync-shuttle.sh` - new share command, argument parsing (**OVERLAPS with PR #2, #3**)
+- `lib/transfer.sh` - pull logic changes (**OVERLAPS with PR #3**)
+- `tests/` - new test cases
+
+### Recommended Approach
+
+**Option A (Recommended): Wait for PRs to merge, then branch from main**
+- Safest, cleanest history
+- No complex stacking or conflict resolution
+- Delay: depends on PR review/merge timeline
+
+**Option B: Stack on PR #3 (create PR #4)**
+- Can start immediately
+- Risk: if PR #2 or #3 changes, need to rebase
+- More complex git management
+
+**Option C: Branch from main, merge later**
+- Independent work
+- Will have merge conflicts with PR #2/#3
+- More work during integration
+
+### Decision
+
+**Option C Selected:** Branch from main, resolve conflicts later.
+
+Rationale:
+- Independent work, not blocked by PR #2/#3 review timeline
+- Conflicts will be resolved during integration
+- Allows parallel progress
+
+**Branch:** `feature/outbox-inbox-symmetry`
+
+---
+
+## Directory Structure (Updated)
+
+### Reserved Namespaces
+
+The following names are **reserved** and cannot be used as server IDs:
+- `global` - used for global shares
+
+### Target Structure
+
+```
+~/.sync-shuttle/local/
+├── inbox/
+│   └── <server_id>/           # Files received FROM this server
+│       └── files...
+└── outbox/
+    ├── global/                # Global share (all servers can pull)
+    │   └── files...
+    └── <server_id>/           # Server-specific share
+        └── files...
+```
+
+**Note:** No files at `outbox/` root level. Everything is namespaced.
+
+### Pull Logic
+
+When pulling from remote, check in order:
+1. `remote:local/outbox/global/` (global shares)
+2. `remote:local/outbox/<your_hostname>/` (server-specific shares)
+
+This prevents accidentally syncing someone else's per-server outbox.
+
+---
+
+## Task Overview
+
+| # | Task | Status | Complexity |
+|---|------|--------|------------|
+| 0 | Add reserved namespace validation ("global" cannot be server ID) | [ ] | Low |
+| 1 | Update pull to check global/ and per-server outbox on remote | [ ] | Medium |
+| 2 | Update directory initialization for new outbox structure | [ ] | Low |
+| 3 | Add optional auto-population of local outbox/<server>/ on push | [ ] | Medium |
+| 4 | Update documentation (SPECIFICATION.md, README.md) | [ ] | Low |
+| 5 | Update tests to reflect new structure | [ ] | Medium |
+| 6 | Add `share` command for managing outbox | [ ] | Medium |
+| 7 | Migrate existing outbox/ files to outbox/global/ | [ ] | Low |
+
+---
+
+$---
+
+## Task 0: Add Reserved Namespace Validation
+
+### Description
+Prevent "global" (and potentially other reserved words) from being used as server IDs.
+
+### Current Code
+Server ID validation exists in `lib/validation.sh` or during config parsing.
+
+### Proposed Change
+```bash
+# Reserved namespaces that cannot be used as server IDs
+readonly RESERVED_NAMESPACES=("global")
+
+validate_server_id() {
+    local server_id="$1"
+
+    # Check reserved namespaces
+    for reserved in "${RESERVED_NAMESPACES[@]}"; do
+        if [[ "$server_id" == "$reserved" ]]; then
+            log_error "Server ID '$server_id' is reserved and cannot be used"
+            return 1
+        fi
+    done
+
+    # ... existing validation ...
+}
+```
+
+### Files Affected
+- `lib/validation.sh` or `sync-shuttle.sh` (server config parsing)
+
+### Verification Steps
+1. Try to add a server with ID "global" - should fail
+2. Existing servers should still work
+3. Error message is clear
+
+### Rollback
+Remove reserved namespace check.
+
+$---
+
+## Task 1: Update Pull to Check Global and Per-Server Outbox on Remote
+
+### Description
+When pulling from a remote server, check both:
+1. `remote:local/outbox/global/` (global share - available to all)
+2. `remote:local/outbox/<your_hostname>/` (server-specific share - just for you)
+
+### Current Code (lib/transfer.sh:236)
+```bash
+local remote_src="${server_user}@${server_host}:${server_remote_base}/local/outbox/"
+```
+
+### Proposed Change
+```bash
+# Pull from both global and per-server outbox
+local remote_global="${server_user}@${server_host}:${server_remote_base}/local/outbox/global/"
+local remote_specific="${server_user}@${server_host}:${server_remote_base}/local/outbox/${HOSTNAME:-$(hostname)}/"
+
+# Pull global first, then server-specific (server-specific can override)
+rsync ... "$remote_global" "$local_dest/"      # Global shares
+rsync ... "$remote_specific" "$local_dest/"    # Server-specific (only if exists)
+```
+
+### Why This Order?
+- Global first, then specific - allows server-specific to override global
+- Only pulls from `global/` and `<hostname>/` - never pulls other server's folders
+
+### Files Affected
+- `lib/transfer.sh` (lines 230-260)
+
+### Verification Steps
+1. Create test file in remote's `outbox/` (global)
+2. Create test file in remote's `outbox/<hostname>/` (specific)
+3. Run pull, verify both files arrive
+4. Verify no errors if specific directory doesn't exist
+
+### Rollback
+Revert to single remote_src if issues arise.
+
+$---
+
+## Task 2: Update Directory Initialization
+
+### Description
+When initializing sync-shuttle, create the per-server outbox structure capability.
+
+### Current Code (sync-shuttle.sh:1181)
+```bash
+for dir in "$CONFIG_DIR" "$REMOTE_DIR" "$INBOX_DIR" "$OUTBOX_DIR" "$LOGS_DIR"; do
+```
+
+### Proposed Change
+No change to init - directories are created on-demand when needed. The structure supports:
+```
+local/outbox/           # Global (already exists)
+local/outbox/<server>/  # Created when sharing with specific server
+```
+
+### Files Affected
+- Potentially `action_init()` if we want to pre-create structure
+- Or no change - create on demand
+
+### Verification Steps
+1. Run `sync-shuttle init` on fresh install
+2. Verify `local/outbox/` exists
+3. Verify per-server dirs created on-demand during push/share
+
+### Rollback
+N/A - minimal change
+
+$---
+
+## Task 3: Auto-Populate Local Outbox on Push (Optional Feature)
+
+### Description
+When pushing files to a server, optionally copy them to `local/outbox/<server>/` as a record of what was shared.
+
+### Current Flow
+```
+User file → staging → remote inbox
+```
+
+### Proposed Flow
+```
+User file → staging → remote inbox
+                   ↘ local outbox/<server>/ (record)
+```
+
+### Implementation Options
+
+**Option A: Always copy to outbox (automatic record)**
+```bash
+# After successful push to remote
+cp -r "$SOURCE_PATH" "${OUTBOX_DIR}/${SERVER_ID}/"
+```
+
+**Option B: Flag to enable (--share)**
+```bash
+sync-shuttle push -s server file.txt --share
+# Pushes AND adds to outbox/<server>/
+```
+
+**Option C: Separate command**
+```bash
+sync-shuttle push -s server file.txt   # Just push
+sync-shuttle share -s server file.txt  # Add to outbox/<server>/
+```
+
+### Recommendation
+Option C - keeps push simple, share is explicit action.
+
+### Files Affected
+- `sync-shuttle.sh` (new `action_share()` function)
+- Argument parsing for new command
+
+### Verification Steps
+1. Run share command
+2. Verify file appears in `outbox/<server>/`
+3. From remote, pull and verify file arrives
+
+### Rollback
+Remove share command, outbox/<server>/ directories.
+
+$---
+
+## Task 4: Update Documentation
+
+### Description
+Update SPECIFICATION.md and README.md to reflect new directory structure.
+
+### Files Affected
+
+**SPECIFICATION.md** (lines 40, 80-82, 170):
+```markdown
+# Before
+│   └── outbox/                # Files staged for sending
+
+# After
+│   └── outbox/                # Files shared with remotes
+│       ├── <server_id>/       # Server-specific shares
+│       └── (global files)     # Available to all servers
+```
+
+**README.md** (line 70):
+```markdown
+# Before
+│   └── outbox/              # Files staged for sending
+
+# After
+│   └── outbox/              # Files shared with remotes (per-server + global)
+```
+
+### Verification Steps
+1. Read updated docs
+2. Verify examples are accurate
+3. Verify no broken references
+
+### Rollback
+Revert markdown changes.
+
+$---
+
+## Task 5: Update Tests
+
+### Description
+Update test fixtures and assertions to handle new outbox structure.
+
+### Files Affected
+- `tests/integration/test_config.sh` (lines 21, 26, 183, 191)
+- `tests/helpers/fixtures.sh` (line 170)
+- `tests/e2e/test_scenarios.sh` (line 39)
+
+### Changes Needed
+1. Update directory creation to optionally include per-server outbox
+2. Add tests for pull from per-server outbox
+3. Add tests for share command (if implemented)
+
+### Verification Steps
+1. Run full test suite: `./tests/run_tests.sh`
+2. Verify all tests pass
+3. Verify new functionality is covered
+
+### Rollback
+Revert test changes.
+
+$---
+
+## Task 6: Add Share Command
+
+### Description
+New command to add files to outbox for a specific server.
+
+### CLI Design
+```bash
+# Add file to server-specific outbox
+sync-shuttle share -s server file.txt
+# → goes to outbox/<server>/
+
+# Add file to global outbox (all servers)
+sync-shuttle share --global file.txt
+# → goes to outbox/global/
+
+# List what's shared
+sync-shuttle share --list
+sync-shuttle share -s server --list
+sync-shuttle share --global --list
+
+# Remove from share
+sync-shuttle share -s server --remove file.txt
+sync-shuttle share --global --remove file.txt
+```
+
+### Implementation
+
+**New function in sync-shuttle.sh:**
+```bash
+action_share() {
+    local share_dir
+
+    if [[ -n "$SERVER_ID" ]]; then
+        share_dir="${OUTBOX_DIR}/${SERVER_ID}"
+    elif [[ "$GLOBAL_MODE" == "true" ]]; then
+        share_dir="${OUTBOX_DIR}/global"
+    else
+        log_error "Must specify -s <server> or --global"
+        exit 2
+    fi
+
+    mkdir -p "$share_dir"
+
+    if [[ "$LIST_MODE" == "true" ]]; then
+        find "$share_dir" -type f
+    elif [[ "$REMOVE_MODE" == "true" ]]; then
+        rm -f "${share_dir}/$(basename "$SOURCE_PATH")"
+    else
+        cp -r "$SOURCE_PATH" "$share_dir/"
+    fi
+}
+```
+
+**Argument parsing additions:**
+- New action: `share`
+- New flags: `--list`, `--remove`, `--global`
+
+### Verification Steps
+1. `share -s server file.txt` - verify file in `outbox/<server>/`
+2. `share --global file.txt` - verify file in `outbox/global/`
+3. `share --list` - verify lists files
+4. `share --remove file.txt` - verify removes file
+5. Remote pull - verify shared files arrive
+
+### Rollback
+Remove action_share function and argument parsing.
+
+$---
+
+## Task 7: Migrate Existing Outbox Files
+
+### Description
+Move any existing files from `outbox/` root to `outbox/global/` for backward compatibility.
+
+### Migration Logic
+```bash
+# One-time migration during init or upgrade
+migrate_outbox() {
+    local outbox_dir="${LOCAL_DIR}/outbox"
+    local global_dir="${outbox_dir}/global"
+
+    # Find files at root level (not in subdirs)
+    local root_files
+    root_files=$(find "$outbox_dir" -maxdepth 1 -type f 2>/dev/null)
+
+    if [[ -n "$root_files" ]]; then
+        mkdir -p "$global_dir"
+        # Move files to global/
+        find "$outbox_dir" -maxdepth 1 -type f -exec mv {} "$global_dir/" \;
+        log_info "Migrated outbox files to outbox/global/"
+    fi
+}
+```
+
+### When to Run
+- During `sync-shuttle init` if existing installation detected
+- Or as a one-time migration command: `sync-shuttle migrate`
+
+### Verification Steps
+1. Create test files in `outbox/` root
+2. Run migration
+3. Verify files moved to `outbox/global/`
+4. Verify no data loss
+
+### Rollback
+Move files back from `outbox/global/` to `outbox/`.
+
+$---
+
+## Execution Order
+
+**Phase 1: Foundation (Tasks 1, 2)**
+- Update pull logic
+- Verify backward compatible
+
+**Phase 2: Core Feature (Tasks 3, 6)**
+- Add share command
+- Optional auto-populate on push
+
+**Phase 3: Polish (Tasks 4, 5)**
+- Documentation
+- Tests
+
+---
+
+## Work Log
+
+Track completed tasks in `work_log.md` in this directory.

--- a/tickets/20260105_outbox_inbox_symmetry/TICKET.md
+++ b/tickets/20260105_outbox_inbox_symmetry/TICKET.md
@@ -1,0 +1,207 @@
+# Ticket: Inbox/Outbox Symmetry and Per-Server Structure
+
+**Type:** Design Issue / Feature Request
+**Priority:** High
+**Status:** In Analysis
+**Created:** 2026-01-05
+**Related:** Feature PR on advanced discoverability
+
+---
+
+## Executive Summary
+
+The inbox and outbox directories have an **asymmetric design** that creates confusion and limits functionality. Inbox is per-server, but outbox is flat. This needs to be aligned for consistency and to support the "push = share with that user" mental model.
+
+---
+
+## Current State
+
+### Directory Structure (Live)
+
+```
+~/.sync-shuttle/local/
+├── inbox/
+│   └── <server_id>/        # PER-SERVER (files received from each server)
+│       └── files...
+└── outbox/
+    └── files...            # FLAT (global, not per-server)
+```
+
+### Current Behavior
+
+| Operation | Source | Destination |
+|-----------|--------|-------------|
+| **PUSH** | User-specified file | Remote's `inbox/<your_hostname>/` |
+| **PULL** | Remote's `outbox/` (flat) | Your `inbox/<server_id>/` |
+
+### Code References
+
+**Push destination** (sync-shuttle.sh:967, lib/transfer.sh:157):
+```bash
+local remote_dest="${server_user}@${server_host}:${server_remote_base}/local/inbox/${HOSTNAME:-$(hostname)}/"
+```
+
+**Pull source** (lib/transfer.sh:236):
+```bash
+local remote_src="${server_user}@${server_host}:${server_remote_base}/local/outbox/"
+```
+
+**Pull destination** (sync-shuttle.sh:1031):
+```bash
+local dest_dir="${INBOX_DIR}/${SERVER_ID}"
+```
+
+**Outbox definition** (sync-shuttle.sh:688):
+```bash
+OUTBOX_DIR="${LOCAL_DIR}/outbox"
+```
+
+---
+
+## The Problem
+
+### 1. Asymmetric Design
+
+- **Inbox**: Per-server (`inbox/<server_id>/`) - you know WHO sent each file
+- **Outbox**: Flat (`outbox/`) - everyone pulls the same files, no control
+
+### 2. No "Share with Specific User" Capability
+
+When you push to server A, you're essentially sharing with that user. But:
+- Push goes to THEIR inbox (good)
+- Your outbox doesn't reflect WHO you shared with
+- They can't re-pull files you previously pushed
+
+### 3. Mental Model Mismatch
+
+Users expect symmetry:
+- "Files I received from server A" → `inbox/serverA/` ✓
+- "Files I'm sharing with server A" → `outbox/serverA/` ✗ (doesn't exist)
+
+### 4. Production Readiness
+
+The current design doesn't match patterns used in production auth/cookie-cutter systems where per-user/per-tenant isolation is standard.
+
+---
+
+## Desired State
+
+### Directory Structure (Target)
+
+```
+~/.sync-shuttle/local/
+├── inbox/
+│   └── <server_id>/           # Files received FROM this server
+│       └── files...
+└── outbox/
+    ├── global/                # Global share (all servers can pull)
+    │   └── files...
+    └── <server_id>/           # Server-specific share
+        └── files...
+```
+
+**Note:** No files at `outbox/` root level. Everything is namespaced.
+
+### Reserved Namespaces
+
+- `global` - cannot be used as a server ID
+
+### Target Behavior
+
+| Operation | Source | Destination |
+|-----------|--------|-------------|
+| **PUSH** | User-specified file | Remote's `inbox/<your_hostname>/` |
+| **SHARE** | User-specified file | Your `outbox/global/` or `outbox/<server_id>/` |
+| **PULL** | Remote's `outbox/global/` + `outbox/<your_hostname>/` | Your `inbox/<server_id>/` |
+
+### The Mental Model
+
+```
+YOUR MACHINE                              REMOTE SERVER
+────────────────────────────────────────────────────────
+
+outbox/<server>/  ──── they pull ────►  (server-specific share)
+outbox/global/    ──── they pull ────►  (global share)
+
+inbox/<server>/   ◄──── pull ──────────  their outbox/global/ + outbox/<you>/
+```
+
+---
+
+## Affected Files
+
+| File | Lines | What Changes |
+|------|-------|--------------|
+| `sync-shuttle.sh` | 688 | OUTBOX_DIR definition |
+| `sync-shuttle.sh` | 1031 | Pull destination logic |
+| `lib/transfer.sh` | 236 | Pull source (needs to check per-server outbox) |
+| `lib/transfer.sh` | 157-171 | Push destination (optionally copy to local outbox record) |
+| `tests/integration/test_config.sh` | 21, 26, 183, 191 | Test assertions for outbox structure |
+| `tests/helpers/fixtures.sh` | 170 | Directory creation |
+| `SPECIFICATION.md` | 40, 82, 170 | Documentation |
+| `README.md` | 70 | Documentation |
+
+---
+
+## Principles Applied
+
+1. **Pure Functional** - Changes are isolated, no side effects on unrelated code
+2. **Pipeline Architecture** - Data flow remains linear (push → stage → sync → record)
+3. **Explicit Contracts** - Directory structure is explicit, documented
+4. **Idempotent** - Re-running push/pull produces same result
+5. **No Magic** - Behavior is clear, no hidden transformations
+6. **Debuggability** - Per-server directories make it easy to see what's shared with whom
+
+---
+
+## Open Questions
+
+1. **Should push auto-populate outbox/<server>/?**
+   - Pro: Creates record of what you shared
+   - Con: Duplicates data (file exists in source + outbox)
+
+2. **Should pull check both outbox/ and outbox/<your_id>/?**
+   - Pro: Server-specific + global shares
+   - Con: More complex logic
+
+3. **Backward compatibility?**
+   - Existing flat outbox/ files should still work
+
+---
+
+## Related Context
+
+### Grep: All Outbox References
+
+```
+sync-shuttle.sh:55:   #   │   └── outbox/              # Files staged for sending
+sync-shuttle.sh:204:  #   # Stage files in outbox
+sync-shuttle.sh:205:  #   cp -r ~/projects/myapp ~/.sync-shuttle/local/outbox/
+sync-shuttle.sh:688:      OUTBOX_DIR="${LOCAL_DIR}/outbox"
+sync-shuttle.sh:1041:     log_info "[DRY-RUN] Would pull from: ...local/outbox/"
+sync-shuttle.sh:1044:     log_info "Pulling from: ...local/outbox/"
+sync-shuttle.sh:1222-1224: outbox_count=$(find "$OUTBOX_DIR" -type f ...)
+lib/transfer.sh:236:  local remote_src="...local/outbox/"
+SPECIFICATION.md:40:  - Local staging: ~/.sync-shuttle/local/outbox/
+SPECIFICATION.md:82:  │   └── outbox/                # Files staged for sending
+SPECIFICATION.md:170: 4. Check pending outbox → List local/outbox/
+```
+
+### Grep: All Inbox References
+
+```
+sync-shuttle.sh:54:   #   │   ├── inbox/               # Files received from remotes
+sync-shuttle.sh:221:  #   ls ~/.sync-shuttle/local/inbox/prod-web-01/
+sync-shuttle.sh:687:      INBOX_DIR="${LOCAL_DIR}/inbox"
+sync-shuttle.sh:967:      remote_dest="...local/inbox/${HOSTNAME}/"
+lib/transfer.sh:157:  remote_dest="...local/inbox/${HOSTNAME}/"
+lib/transfer.sh:171:  mkdir -p '...local/inbox/${HOSTNAME}'
+SPECIFICATION.md:41:  - Incoming files: ~/.sync-shuttle/local/inbox/
+SPECIFICATION.md:81:  │   ├── inbox/                 # Files received from remotes
+```
+
+---
+
+## Next Steps
+
+See IMPLEMENTATION_PLAN.md for detailed tasks.

--- a/tickets/20260105_outbox_inbox_symmetry/work_log.md
+++ b/tickets/20260105_outbox_inbox_symmetry/work_log.md
@@ -19,6 +19,8 @@
 | 2026-01-05 | 2 | Reviewed directory initialization | No changes needed |
 | 2026-01-05 | 2 | Verification: OUTBOX_DIR created in init | ✅ (line 766) |
 | 2026-01-05 | 2 | Verification: subdirs created on-demand | ✅ (by design) |
+| 2026-01-05 | 3 | Decision: Option C selected | Separate share command (Task 6) |
+| 2026-01-05 | 3 | No changes to push command | Push remains simple |
 
 ---
 
@@ -27,7 +29,7 @@
 - [x] Task 0: Add reserved namespace validation ("global")
 - [x] Task 1: Update pull to check global/ and per-server outbox
 - [x] Task 2: Update directory initialization
-- [ ] Task 3: Auto-populate local outbox on push (optional)
+- [x] Task 3: Auto-populate local outbox on push (optional)
 - [ ] Task 4: Update documentation
 - [ ] Task 5: Update tests
 - [ ] Task 6: Add share command

--- a/tickets/20260105_outbox_inbox_symmetry/work_log.md
+++ b/tickets/20260105_outbox_inbox_symmetry/work_log.md
@@ -24,6 +24,9 @@
 | 2026-01-05 | 4 | Updated SPECIFICATION.md | Lines 40, 81-85, 173 |
 | 2026-01-05 | 4 | Updated README.md | Lines 69-73 |
 | 2026-01-05 | 4 | Verification: directory structure accurate | ✅ |
+| 2026-01-05 | 5 | Added server ID validation tests | test_validation.sh:253-296 |
+| 2026-01-05 | 5 | Verification: syntax check passed | ✅ |
+| 2026-01-05 | 5 | Note: share command tests deferred to Task 6 | - |
 
 ---
 
@@ -34,6 +37,6 @@
 - [x] Task 2: Update directory initialization
 - [x] Task 3: Auto-populate local outbox on push (optional)
 - [x] Task 4: Update documentation
-- [ ] Task 5: Update tests
+- [x] Task 5: Update tests
 - [ ] Task 6: Add share command
 - [ ] Task 7: Migrate existing outbox/ files to outbox/global/

--- a/tickets/20260105_outbox_inbox_symmetry/work_log.md
+++ b/tickets/20260105_outbox_inbox_symmetry/work_log.md
@@ -32,6 +32,10 @@
 | 2026-01-05 | 6 | Verification: share --global file works | ✅ |
 | 2026-01-05 | 6 | Verification: share --list works | ✅ |
 | 2026-01-05 | 6 | Verification: share --remove works | ✅ |
+| 2026-01-05 | 7 | Added migrate_outbox_to_global() | sync-shuttle.sh:670-699 |
+| 2026-01-05 | 7 | Added migration call for < 1.2.0 | sync-shuttle.sh:717-719 |
+| 2026-01-05 | 7 | Bumped version to 1.2.0 | sync-shuttle.sh:320 |
+| 2026-01-05 | 7 | Verification: files moved to global/ | ✅ |
 
 ---
 
@@ -44,4 +48,4 @@
 - [x] Task 4: Update documentation
 - [x] Task 5: Update tests
 - [x] Task 6: Add share command
-- [ ] Task 7: Migrate existing outbox/ files to outbox/global/
+- [x] Task 7: Migrate existing outbox/ files to outbox/global/

--- a/tickets/20260105_outbox_inbox_symmetry/work_log.md
+++ b/tickets/20260105_outbox_inbox_symmetry/work_log.md
@@ -16,6 +16,9 @@
 | 2026-01-05 | 1 | Verification: syntax check passed | ✅ |
 | 2026-01-05 | 1 | Verification: exit code 23 handling for missing dirs | ✅ |
 | 2026-01-05 | 1 | Verification: e2e with remote server | ⏸️ Pending integration test |
+| 2026-01-05 | 2 | Reviewed directory initialization | No changes needed |
+| 2026-01-05 | 2 | Verification: OUTBOX_DIR created in init | ✅ (line 766) |
+| 2026-01-05 | 2 | Verification: subdirs created on-demand | ✅ (by design) |
 
 ---
 
@@ -23,7 +26,7 @@
 
 - [x] Task 0: Add reserved namespace validation ("global")
 - [x] Task 1: Update pull to check global/ and per-server outbox
-- [ ] Task 2: Update directory initialization
+- [x] Task 2: Update directory initialization
 - [ ] Task 3: Auto-populate local outbox on push (optional)
 - [ ] Task 4: Update documentation
 - [ ] Task 5: Update tests

--- a/tickets/20260105_outbox_inbox_symmetry/work_log.md
+++ b/tickets/20260105_outbox_inbox_symmetry/work_log.md
@@ -36,6 +36,8 @@
 | 2026-01-05 | 7 | Added migration call for < 1.2.0 | sync-shuttle.sh:717-719 |
 | 2026-01-05 | 7 | Bumped version to 1.2.0 | sync-shuttle.sh:320 |
 | 2026-01-05 | 7 | Verification: files moved to global/ | ✅ |
+| 2026-01-05 | - | Audit: verified installer triggers migrations | ✅ |
+| 2026-01-05 | - | Audit: added share command to README.md | Fixed |
 
 ---
 

--- a/tickets/20260105_outbox_inbox_symmetry/work_log.md
+++ b/tickets/20260105_outbox_inbox_symmetry/work_log.md
@@ -12,13 +12,17 @@
 | 2026-01-05 | - | Updated plan with global/ namespace | Per user feedback |
 | 2026-01-05 | - | Added git strategy analysis | PR #2, #3 overlap identified |
 | 2026-01-05 | 0 | Implemented reserved namespace validation | Added check in validate_server_id() |
+| 2026-01-05 | 1 | Updated pull to check global/ and per-server outbox | Modified perform_rsync_pull() |
+| 2026-01-05 | 1 | Verification: syntax check passed | ✅ |
+| 2026-01-05 | 1 | Verification: exit code 23 handling for missing dirs | ✅ |
+| 2026-01-05 | 1 | Verification: e2e with remote server | ⏸️ Pending integration test |
 
 ---
 
 ## Task Completion Status
 
 - [x] Task 0: Add reserved namespace validation ("global")
-- [ ] Task 1: Update pull to check global/ and per-server outbox
+- [x] Task 1: Update pull to check global/ and per-server outbox
 - [ ] Task 2: Update directory initialization
 - [ ] Task 3: Auto-populate local outbox on push (optional)
 - [ ] Task 4: Update documentation

--- a/tickets/20260105_outbox_inbox_symmetry/work_log.md
+++ b/tickets/20260105_outbox_inbox_symmetry/work_log.md
@@ -11,12 +11,13 @@
 | 2026-01-05 | - | Created ticket and implementation plan | Initial analysis complete |
 | 2026-01-05 | - | Updated plan with global/ namespace | Per user feedback |
 | 2026-01-05 | - | Added git strategy analysis | PR #2, #3 overlap identified |
+| 2026-01-05 | 0 | Implemented reserved namespace validation | Added check in validate_server_id() |
 
 ---
 
 ## Task Completion Status
 
-- [ ] Task 0: Add reserved namespace validation ("global")
+- [x] Task 0: Add reserved namespace validation ("global")
 - [ ] Task 1: Update pull to check global/ and per-server outbox
 - [ ] Task 2: Update directory initialization
 - [ ] Task 3: Auto-populate local outbox on push (optional)

--- a/tickets/20260105_outbox_inbox_symmetry/work_log.md
+++ b/tickets/20260105_outbox_inbox_symmetry/work_log.md
@@ -1,0 +1,26 @@
+# Work Log: Inbox/Outbox Symmetry
+
+**Ticket:** 20260105_outbox_inbox_symmetry
+
+---
+
+## Log Entries
+
+| Date | Task # | Action | Notes |
+|------|--------|--------|-------|
+| 2026-01-05 | - | Created ticket and implementation plan | Initial analysis complete |
+| 2026-01-05 | - | Updated plan with global/ namespace | Per user feedback |
+| 2026-01-05 | - | Added git strategy analysis | PR #2, #3 overlap identified |
+
+---
+
+## Task Completion Status
+
+- [ ] Task 0: Add reserved namespace validation ("global")
+- [ ] Task 1: Update pull to check global/ and per-server outbox
+- [ ] Task 2: Update directory initialization
+- [ ] Task 3: Auto-populate local outbox on push (optional)
+- [ ] Task 4: Update documentation
+- [ ] Task 5: Update tests
+- [ ] Task 6: Add share command
+- [ ] Task 7: Migrate existing outbox/ files to outbox/global/

--- a/tickets/20260105_outbox_inbox_symmetry/work_log.md
+++ b/tickets/20260105_outbox_inbox_symmetry/work_log.md
@@ -38,6 +38,7 @@
 | 2026-01-05 | 7 | Verification: files moved to global/ | ✅ |
 | 2026-01-05 | - | Audit: verified installer triggers migrations | ✅ |
 | 2026-01-05 | - | Audit: added share command to README.md | Fixed |
+| 2026-01-05 | - | Audit: added share command to --help output | Fixed |
 
 ---
 

--- a/tickets/20260105_outbox_inbox_symmetry/work_log.md
+++ b/tickets/20260105_outbox_inbox_symmetry/work_log.md
@@ -21,6 +21,9 @@
 | 2026-01-05 | 2 | Verification: subdirs created on-demand | ✅ (by design) |
 | 2026-01-05 | 3 | Decision: Option C selected | Separate share command (Task 6) |
 | 2026-01-05 | 3 | No changes to push command | Push remains simple |
+| 2026-01-05 | 4 | Updated SPECIFICATION.md | Lines 40, 81-85, 173 |
+| 2026-01-05 | 4 | Updated README.md | Lines 69-73 |
+| 2026-01-05 | 4 | Verification: directory structure accurate | ✅ |
 
 ---
 
@@ -30,7 +33,7 @@
 - [x] Task 1: Update pull to check global/ and per-server outbox
 - [x] Task 2: Update directory initialization
 - [x] Task 3: Auto-populate local outbox on push (optional)
-- [ ] Task 4: Update documentation
+- [x] Task 4: Update documentation
 - [ ] Task 5: Update tests
 - [ ] Task 6: Add share command
 - [ ] Task 7: Migrate existing outbox/ files to outbox/global/

--- a/tickets/20260105_outbox_inbox_symmetry/work_log.md
+++ b/tickets/20260105_outbox_inbox_symmetry/work_log.md
@@ -39,6 +39,9 @@
 | 2026-01-05 | - | Audit: verified installer triggers migrations | ✅ |
 | 2026-01-05 | - | Audit: added share command to README.md | Fixed |
 | 2026-01-05 | - | Audit: added share command to --help output | Fixed |
+| 2026-01-05 | - | Added ShareScreen to TUI | tui/sync_tui.py:528-656 |
+| 2026-01-05 | - | Added Share button and 'h' keybinding | MainScreen updated |
+| 2026-01-05 | - | Verification: Python syntax check passed | ✅ |
 
 ---
 

--- a/tickets/20260105_outbox_inbox_symmetry/work_log.md
+++ b/tickets/20260105_outbox_inbox_symmetry/work_log.md
@@ -42,6 +42,13 @@
 | 2026-01-05 | - | Added ShareScreen to TUI | tui/sync_tui.py:528-656 |
 | 2026-01-05 | - | Added Share button and 'h' keybinding | MainScreen updated |
 | 2026-01-05 | - | Verification: Python syntax check passed | ✅ |
+| 2026-01-05 | - | Redesigned TUI with Apple UX principles | Full rewrite |
+| 2026-01-05 | - | Added tabbed navigation | Servers, Inbox, Outbox, Activity |
+| 2026-01-05 | - | Added quick stats bar | File counts in header |
+| 2026-01-05 | - | Added modal dialogs | QuickShareDialog, QuickPushDialog |
+| 2026-01-05 | - | Added empty states with guidance | Better onboarding |
+| 2026-01-05 | - | Improved keyboard shortcuts | p=Push, u=Pull, s=Share, 1-4=Tabs |
+| 2026-01-05 | - | Verification: Python syntax check passed | ✅ |
 
 ---
 

--- a/tickets/20260105_outbox_inbox_symmetry/work_log.md
+++ b/tickets/20260105_outbox_inbox_symmetry/work_log.md
@@ -27,6 +27,11 @@
 | 2026-01-05 | 5 | Added server ID validation tests | test_validation.sh:253-296 |
 | 2026-01-05 | 5 | Verification: syntax check passed | ✅ |
 | 2026-01-05 | 5 | Note: share command tests deferred to Task 6 | - |
+| 2026-01-05 | 6 | Implemented action_share() | sync-shuttle.sh:1082-1213 |
+| 2026-01-05 | 6 | Added --global, --list, --remove flags | sync-shuttle.sh:558-569 |
+| 2026-01-05 | 6 | Verification: share --global file works | ✅ |
+| 2026-01-05 | 6 | Verification: share --list works | ✅ |
+| 2026-01-05 | 6 | Verification: share --remove works | ✅ |
 
 ---
 
@@ -38,5 +43,5 @@
 - [x] Task 3: Auto-populate local outbox on push (optional)
 - [x] Task 4: Update documentation
 - [x] Task 5: Update tests
-- [ ] Task 6: Add share command
+- [x] Task 6: Add share command
 - [ ] Task 7: Migrate existing outbox/ files to outbox/global/

--- a/tickets/20260105_rsync_delta_transfer/TICKET.md
+++ b/tickets/20260105_rsync_delta_transfer/TICKET.md
@@ -1,0 +1,204 @@
+# Ticket: Enable rsync Delta Transfers for Performance
+
+**Type:** Performance Bug
+**Priority:** High
+**Status:** Open
+**Created:** 2026-01-05
+
+---
+
+## Problem
+
+Sync-shuttle is significantly slower than it should be because `--ignore-existing` prevents rsync's delta transfer algorithm from working.
+
+### Current Behavior
+
+In `lib/transfer.sh:53`:
+```bash
+options+=("--ignore-existing" "--backup" "--backup-dir=.sync-shuttle-backup")
+```
+
+The `--ignore-existing` flag tells rsync to **skip any file that already exists** at the destination, regardless of whether it has changed.
+
+### Impact
+
+| Scenario | Expected | Actual |
+|----------|----------|--------|
+| Push new file | Copy file | Copy file ✓ |
+| Push changed file | Delta transfer (only changes) | **SKIPPED entirely** |
+| Push unchanged file | Skip (no transfer) | Skip ✓ |
+| Re-push same file | Skip or delta | **SKIPPED, no update** |
+
+### Why This Matters
+
+rsync's delta transfer algorithm is its killer feature:
+- For a 100MB file with 1KB change → transfers ~1KB
+- With `--ignore-existing` → transfers 0 bytes (file skipped, no update)
+
+Users who modify a file and re-push will see:
+1. rsync reports "0 files transferred"
+2. File on remote is NOT updated
+3. User uses `--force` in frustration
+4. `--force` triggers full file copy (no delta)
+
+---
+
+## Root Cause Analysis
+
+The `--ignore-existing` flag was likely added for safety (don't overwrite remote files). However, this completely bypasses rsync's incremental update capability.
+
+### Code Path
+
+```
+sync-shuttle push -s server -S file.txt
+        │
+        ▼
+perform_rsync_push(source, staging/)     ← --ignore-existing
+        │
+        ▼
+sync_to_remote(server, staging/)         ← --ignore-existing
+        │
+        ▼
+Remote: inbox/<hostname>/file.txt        ← Never updated if exists
+```
+
+---
+
+## Proposed Solutions
+
+### Option A: Use `--update` (Recommended)
+
+Replace `--ignore-existing` with `--update`:
+
+```bash
+# Before
+options+=("--ignore-existing" "--backup" "--backup-dir=.sync-shuttle-backup")
+
+# After
+options+=("--update" "--backup" "--backup-dir=.sync-shuttle-backup")
+```
+
+**Behavior:**
+- Only overwrites if source is **newer** (by mtime)
+- Enables delta transfers for changed files
+- Still safe: won't overwrite newer destination files
+
+**Pros:**
+- Simple one-line change
+- Enables delta transfers
+- Still prevents accidental overwrites of newer files
+
+**Cons:**
+- Relies on mtime accuracy
+- Won't update if dest is newer (even if user wants to)
+
+---
+
+### Option B: Use `--checksum` with `--update`
+
+```bash
+options+=("--checksum" "--update" "--backup" "--backup-dir=.sync-shuttle-backup")
+```
+
+**Behavior:**
+- Compares files by checksum, not mtime
+- Only transfers if content actually differs
+- Delta transfer for changed content
+
+**Pros:**
+- Most accurate change detection
+- Works even if mtimes are unreliable
+
+**Cons:**
+- Slower initial scan (must checksum all files)
+- More CPU usage
+
+---
+
+### Option C: Remove `--ignore-existing` entirely
+
+```bash
+options+=("--backup" "--backup-dir=.sync-shuttle-backup")
+```
+
+**Behavior:**
+- Always syncs source to destination
+- Existing files are backed up before overwrite
+- Full delta transfer capability
+
+**Pros:**
+- Maximum rsync efficiency
+- Backups provide safety net
+
+**Cons:**
+- May overwrite files user wanted to keep
+- Relies on backup for recovery
+
+---
+
+### Option D: Make it configurable
+
+Add to `sync-shuttle.conf`:
+```bash
+# Sync mode: "safe" (ignore-existing), "update" (newer wins), "sync" (always)
+SYNC_MODE="update"
+```
+
+**Pros:**
+- User choice
+- Backward compatible (default to current behavior)
+
+**Cons:**
+- More complexity
+- Users must understand the options
+
+---
+
+## Recommendation
+
+**Option A (`--update`)** provides the best balance:
+- Enables delta transfers (major performance win)
+- Still safe (won't overwrite newer files)
+- Simple change, low risk
+
+For users who need checksum-based comparison, add `--checksum` to `RSYNC_OPTIONS` in config.
+
+---
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `lib/transfer.sh:53` | Replace `--ignore-existing` with `--update` |
+| `SPECIFICATION.md` | Document sync behavior |
+| `README.md` | Note about delta transfers |
+
+---
+
+## Testing Plan
+
+1. Create a 10MB test file, push to remote
+2. Modify 1 byte in the file
+3. Push again, verify:
+   - rsync shows delta transfer (not full file)
+   - File on remote is updated
+   - Transfer completes in < 1 second
+4. Push unchanged file, verify skip
+5. Test `--force` still works
+
+---
+
+## Performance Expectation
+
+| File Size | Change Size | Current | With Fix |
+|-----------|-------------|---------|----------|
+| 100 MB | 1 KB | Skipped (no update) | ~1 KB transfer |
+| 100 MB | 1 KB + force | 100 MB | ~1 KB transfer |
+| 1 GB | 10 KB | Skipped | ~10 KB transfer |
+
+---
+
+## References
+
+- rsync man page: `--ignore-existing`, `--update`, `--checksum`
+- rsync delta algorithm: https://rsync.samba.org/tech_report/

--- a/tickets/20260105_tui_help_tab/TICKET.md
+++ b/tickets/20260105_tui_help_tab/TICKET.md
@@ -1,0 +1,49 @@
+# Ticket: TUI Help Tab and Activity Log
+
+**Type:** Feature
+**Priority:** Medium
+**Status:** Complete
+**Created:** 2026-01-05
+
+---
+
+## Changes
+
+### 1. Added Help Tab
+
+Added a comprehensive Help tab (key: 5) with:
+- Keyboard shortcuts reference
+- Tabs overview
+- Directory structure explanation
+- Full CLI command reference
+- Workflow examples
+- Safety features documentation
+- Configuration guide
+
+### 2. Improved Activity Tab
+
+Changed Activity tab to read from `sync.log` (human-readable) instead of `sync.jsonl`:
+- Shows last 30 log lines
+- Color-coded by log level:
+  - Red: [ERROR]
+  - Green: [SUCCESS]
+  - Yellow: [WARN]
+  - Blue: [INFO]
+
+### 3. Updated Keybindings
+
+- Added `5` to switch to Help tab
+- Renamed `?` action to `show_help` (shows quick notification)
+
+---
+
+## Files Changed
+
+- `tui/sync_tui.py`
+  - Added HELP_TEXT constant
+  - Added load_log_lines() function
+  - Added Help TabPane
+  - Updated Activity TabPane to use log lines
+  - Added action_tab_help()
+  - Renamed action_help() to action_show_help()
+  - Updated BINDINGS

--- a/tickets/20260105_tui_scrollable_fix/TICKET.md
+++ b/tickets/20260105_tui_scrollable_fix/TICKET.md
@@ -2,7 +2,7 @@
 
 **Type:** Bug Fix
 **Priority:** High
-**Status:** In Progress
+**Status:** Complete
 **Created:** 2026-01-05
 
 ---

--- a/tickets/20260105_tui_scrollable_fix/TICKET.md
+++ b/tickets/20260105_tui_scrollable_fix/TICKET.md
@@ -1,0 +1,53 @@
+# Ticket: TUI ScrollableContainer CSS Bug
+
+**Type:** Bug Fix
+**Priority:** High
+**Status:** In Progress
+**Created:** 2026-01-05
+
+---
+
+## Problem
+
+TUI renders blank content when `ScrollableContainer` is used inside `TabPane`.
+
+### Root Cause
+
+CSS rule in `tui/sync_tui.py`:
+```css
+ScrollableContainer {
+    height: 100%;
+}
+```
+
+This causes the ScrollableContainer to collapse to zero height inside TabbedContent/TabPane.
+
+### Evidence
+
+| Test | CSS | Result |
+|------|-----|--------|
+| test_scroll1 | No ScrollableContainer CSS | Works |
+| test_scroll2 | `height: 1fr` | Blank |
+| test_scroll3 | `min-height: 5` | Works |
+| test_scroll4 | `height: 100%` | Blank |
+
+---
+
+## Solution
+
+Remove the `height: 100%` rule from ScrollableContainer CSS. The container will size naturally based on content and parent constraints.
+
+### Files Changed
+
+- `tui/sync_tui.py` - Remove CSS rule (line ~632)
+
+---
+
+## Testing
+
+1. Run `sync-shuttle tui`
+2. Verify all tabs show content:
+   - Servers tab: server list or empty state
+   - Inbox tab: file tree or empty state
+   - Outbox tab: file tree or empty state
+   - Activity tab: activity table or empty state

--- a/tickets/BUG_RSYNC_FOLDER_STRUCTURE.md
+++ b/tickets/BUG_RSYNC_FOLDER_STRUCTURE.md
@@ -13,16 +13,16 @@ When pushing a directory with a trailing slash (e.g., `00081/`), the folder stru
 
 ```bash
 # On local machine - NOTE THE TRAILING SLASH
-sync-shuttle push -s myserver -S ~/myproject/
+bucketcast push -s myserver -S ~/myproject/
 
 # Expected on remote:
-~/.sync-shuttle/local/inbox/<hostname>/myproject/
+~/.bucketcast/local/inbox/<hostname>/myproject/
 ├── file1.txt
 ├── file2.txt
 └── subdir/
 
 # Actual on remote:
-~/.sync-shuttle/local/inbox/<hostname>/
+~/.bucketcast/local/inbox/<hostname>/
 ├── file1.txt      ← contents dumped directly, folder name lost
 ├── file2.txt
 └── subdir/
@@ -48,14 +48,14 @@ rsync copies CONTENTS of `00081` directly into staging, losing the folder name.
 Strip trailing slashes from SOURCE_PATH in argument parsing:
 
 ```bash
-# In sync-shuttle.sh, after setting SOURCE_PATH
+# In bucketcast.sh, after setting SOURCE_PATH
 SOURCE_PATH="${SOURCE_PATH%/}"  # Remove trailing slash
 ```
 
 ## Why NOT in sync_to_remote?
 
 The `sync_to_remote()` function correctly uses `$local_dir/` with trailing slash because:
-- `local_dir` = `~/.sync-shuttle/remote/<server>/files` (staging container)
+- `local_dir` = `~/.bucketcast/remote/<server>/files` (staging container)
 - We WANT to copy contents of `files/` (which contains `mydir/`) to remote
 - Result: `inbox/hostname/mydir/` ✓
 
@@ -72,9 +72,9 @@ The bug is in the input, not the sync function.
 
 ```bash
 # Should preserve folder name
-sync-shuttle push -s test -S ./testdir/ --dry-run
-# Verify staging: ~/.sync-shuttle/remote/test/files/testdir/ exists
+bucketcast push -s test -S ./testdir/ --dry-run
+# Verify staging: ~/.bucketcast/remote/test/files/testdir/ exists
 
 # Without trailing slash should also work
-sync-shuttle push -s test -S ./testdir --dry-run
+bucketcast push -s test -S ./testdir --dry-run
 ```

--- a/tickets/BUG_STAGING_ACCUMULATION.md
+++ b/tickets/BUG_STAGING_ACCUMULATION.md
@@ -9,24 +9,24 @@
 
 ## Summary
 
-The push staging directory (`~/.sync-shuttle/remote/<server>/files/`) accumulates files across pushes. Each subsequent push re-syncs ALL previously staged files to the remote, not just the new ones.
+The push staging directory (`~/.bucketcast/remote/<server>/files/`) accumulates files across pushes. Each subsequent push re-syncs ALL previously staged files to the remote, not just the new ones.
 
 ## Steps to Reproduce
 
 ```bash
 # Day 1: Push 10 files
-sync-shuttle push -s myserver file1 file2 ... file10
+bucketcast push -s myserver file1 file2 ... file10
 # Result: 10 files synced ✓
 
 # Day 2: Push 1 new file
-sync-shuttle push -s myserver newfile.txt
+bucketcast push -s myserver newfile.txt
 # Expected: 1 file synced
 # Actual: 11 files synced (10 old + 1 new)
 ```
 
 ## Root Cause
 
-1. Files are staged to persistent directory: `~/.sync-shuttle/remote/<server>/files/`
+1. Files are staged to persistent directory: `~/.bucketcast/remote/<server>/files/`
 2. `sync_to_remote()` syncs entire staging directory to remote
 3. No cleanup after successful sync
 4. Staging accumulates indefinitely
@@ -71,7 +71,7 @@ staging_dir="${REMOTE_DIR}/${SERVER_ID}/push-${OPERATION_UUID}"
 
 ### Implementation:
 
-**In `action_push()` (sync-shuttle.sh:954-990):**
+**In `action_push()` (bucketcast.sh:954-990):**
 
 ```bash
 # Create operation-specific staging directory under server's remote dir
@@ -91,13 +91,13 @@ rm -rf "$staging_dir"
 
 **Cleanup on failure/interrupt:**
 - Failed operations leave staging for debugging
-- Can be manually cleaned: `rm -rf ~/.sync-shuttle/remote/*/push-*`
+- Can be manually cleaned: `rm -rf ~/.bucketcast/remote/*/push-*`
 
 ### Migration:
 
 Old staging dirs can be cleaned manually or via future `cleanup` command:
 ```bash
-rm -rf ~/.sync-shuttle/remote/*/files/*
+rm -rf ~/.bucketcast/remote/*/files/*
 ```
 
 ## Safety Checklist

--- a/tui/bucketcast_tui.py
+++ b/tui/bucketcast_tui.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """
-Sync Shuttle - Terminal User Interface
+Bucketcast - Terminal User Interface
 =======================================
 
 A clean, intuitive interface for file synchronization.
 Designed with clarity, simplicity, and user experience in mind.
 
 Usage:
-    python3 sync_tui.py [--base-dir ~/.sync-shuttle]
+    python3 bucketcast_tui.py [--base-dir ~/.bucketcast]
 """
 
 import argparse
@@ -49,7 +49,7 @@ except ImportError:
 
 HELP_TEXT = """
 [bold cyan]═══════════════════════════════════════════════════════════════════════════════[/bold cyan]
-[bold cyan]                           SYNC SHUTTLE - HELP                                  [/bold cyan]
+[bold cyan]                           BUCKETCAST - HELP                                  [/bold cyan]
 [bold cyan]═══════════════════════════════════════════════════════════════════════════════[/bold cyan]
 
 [bold yellow]KEYBOARD SHORTCUTS[/bold yellow]
@@ -72,9 +72,9 @@ HELP_TEXT = """
 
 [bold yellow]DIRECTORY STRUCTURE[/bold yellow]
 ────────────────────────────────────────────────────────────────────────────────
-  ~/.sync-shuttle/
+  ~/.bucketcast/
   ├── config/
-  │   ├── sync-shuttle.conf     Main configuration
+  │   ├── bucketcast.conf     Main configuration
   │   └── servers.toml          Server definitions
   ├── local/
   │   ├── inbox/<server>/       Files received from each server
@@ -87,68 +87,68 @@ HELP_TEXT = """
 
 [bold yellow]CLI COMMANDS[/bold yellow]
 ────────────────────────────────────────────────────────────────────────────────
-  [bold]sync-shuttle init[/bold]
+  [bold]bucketcast init[/bold]
       Initialize directory structure (run once)
 
-  [bold]sync-shuttle push -s <server> -S <file>[/bold]
+  [bold]bucketcast push -s <server> -S <file>[/bold]
       Push a file to a server's inbox
       Add --dry-run to preview without executing
       Add --force to allow overwrites
 
-  [bold]sync-shuttle pull -s <server>[/bold]
+  [bold]bucketcast pull -s <server>[/bold]
       Pull files from a server's outbox (global + your hostname)
       Add --dry-run to preview
 
-  [bold]sync-shuttle share --global -S <file>[/bold]
+  [bold]bucketcast share --global -S <file>[/bold]
       Share a file with ALL servers (goes to outbox/global/)
 
-  [bold]sync-shuttle share -s <server> -S <file>[/bold]
+  [bold]bucketcast share -s <server> -S <file>[/bold]
       Share a file with a SPECIFIC server (goes to outbox/<server>/)
 
-  [bold]sync-shuttle share --list[/bold]
+  [bold]bucketcast share --list[/bold]
       List all currently shared files
 
-  [bold]sync-shuttle share --remove --global -S <file>[/bold]
+  [bold]bucketcast share --remove --global -S <file>[/bold]
       Remove a file from global share
 
-  [bold]sync-shuttle list servers[/bold]
+  [bold]bucketcast list servers[/bold]
       List all configured servers
 
-  [bold]sync-shuttle list files -s <server>[/bold]
+  [bold]bucketcast list files -s <server>[/bold]
       List files synced with a server
 
-  [bold]sync-shuttle status[/bold]
+  [bold]bucketcast status[/bold]
       Show sync status and recent operations
 
-  [bold]sync-shuttle tui[/bold]
+  [bold]bucketcast tui[/bold]
       Launch this interactive interface
 
 [bold yellow]WORKFLOW EXAMPLES[/bold yellow]
 ────────────────────────────────────────────────────────────────────────────────
   [bold]Send a file to a colleague:[/bold]
-    sync-shuttle push -s their-server -S ~/document.pdf
+    bucketcast push -s their-server -S ~/document.pdf
 
   [bold]Receive files from a colleague:[/bold]
-    sync-shuttle pull -s their-server
-    ls ~/.sync-shuttle/local/inbox/their-server/
+    bucketcast pull -s their-server
+    ls ~/.bucketcast/local/inbox/their-server/
 
   [bold]Share a file for anyone to pull:[/bold]
-    sync-shuttle share --global -S ~/shared-notes.txt
+    bucketcast share --global -S ~/shared-notes.txt
 
   [bold]Check what you're sharing:[/bold]
-    sync-shuttle share --list
+    bucketcast share --list
 
 [bold yellow]SAFETY FEATURES[/bold yellow]
 ────────────────────────────────────────────────────────────────────────────────
-  • All files stay in ~/.sync-shuttle/ (sandboxed)
-  • Files are NEVER deleted by sync-shuttle
+  • All files stay in ~/.bucketcast/ (sandboxed)
+  • Files are NEVER deleted by bucketcast
   • Existing files are NEVER overwritten without --force
   • Use --dry-run to preview any operation
   • All operations are logged
 
 [bold yellow]CONFIGURATION[/bold yellow]
 ────────────────────────────────────────────────────────────────────────────────
-  Edit servers: ~/.sync-shuttle/config/servers.toml
+  Edit servers: ~/.bucketcast/config/servers.toml
 
   Example server entry:
     [servers.myserver]
@@ -156,7 +156,7 @@ HELP_TEXT = """
     host = "192.168.1.100"
     port = 22
     user = "myuser"
-    remote_base = "/home/myuser/.sync-shuttle"
+    remote_base = "/home/myuser/.bucketcast"
     enabled = true
 
 [bold cyan]═══════════════════════════════════════════════════════════════════════════════[/bold cyan]
@@ -575,8 +575,8 @@ class QuickPullDialog(ModalScreen):
 # MAIN APPLICATION
 # =============================================================================
 
-class SyncShuttleTUI(App):
-    """Sync Shuttle - Clean, intuitive file synchronization."""
+class BucketcastTUI(App):
+    """Bucketcast - Clean, intuitive file synchronization."""
 
     CSS = """
     /* Global */
@@ -765,7 +765,7 @@ class SyncShuttleTUI(App):
     /* Scrollable areas - no height constraint, let content size naturally */
     """
 
-    TITLE = "Sync Shuttle"
+    TITLE = "Bucketcast"
     BINDINGS = [
         Binding("q", "quit", "Quit"),
         Binding("r", "refresh", "Refresh"),
@@ -804,7 +804,7 @@ class SyncShuttleTUI(App):
                         icon="📡",
                         title="No Servers Configured",
                         subtitle="Add servers to start syncing files",
-                        action="Edit ~/.sync-shuttle/config/servers.toml"
+                        action="Edit ~/.bucketcast/config/servers.toml"
                     )
                 else:
                     yield Static("[bold]Your Servers[/bold]\n", classes="section-title")
@@ -958,7 +958,7 @@ class SyncShuttleTUI(App):
         self._execute_share(target, source)
 
     def _execute_push(self, server_id: str, source: str) -> None:
-        script = Path(__file__).parent.parent / "sync-shuttle.sh"
+        script = Path(__file__).parent.parent / "bucketcast.sh"
         args = ["push", "--server", server_id, "--source", source]
         self.notify(f"Pushing to {server_id}...", timeout=2)
         try:
@@ -976,7 +976,7 @@ class SyncShuttleTUI(App):
             self.notify(f"Error: {e}", severity="error")
 
     def _execute_pull(self, server_id: str) -> None:
-        script = Path(__file__).parent.parent / "sync-shuttle.sh"
+        script = Path(__file__).parent.parent / "bucketcast.sh"
         args = ["pull", "--server", server_id]
         self.notify(f"Pulling from {server_id}...", timeout=2)
         try:
@@ -995,7 +995,7 @@ class SyncShuttleTUI(App):
             self.notify(f"Error: {e}", severity="error")
 
     def _execute_share(self, target: str, source: str) -> None:
-        script = Path(__file__).parent.parent / "sync-shuttle.sh"
+        script = Path(__file__).parent.parent / "bucketcast.sh"
         if target == "global":
             args = ["share", "--global", "--source", source]
         else:
@@ -1022,12 +1022,12 @@ class SyncShuttleTUI(App):
 # =============================================================================
 
 def main():
-    parser = argparse.ArgumentParser(description="Sync Shuttle TUI")
+    parser = argparse.ArgumentParser(description="Bucketcast TUI")
     parser.add_argument(
         "--base-dir",
         type=Path,
-        default=Path.home() / ".sync-shuttle",
-        help="Base directory for sync-shuttle"
+        default=Path.home() / ".bucketcast",
+        help="Base directory for bucketcast"
     )
     parser.add_argument(
         "--config-dir",
@@ -1044,10 +1044,10 @@ def main():
 
     if not base_dir.exists():
         print(f"Error: Base directory does not exist: {base_dir}")
-        print("Run 'sync-shuttle init' first.")
+        print("Run 'bucketcast init' first.")
         sys.exit(1)
 
-    app = SyncShuttleTUI(base_dir, config_dir)
+    app = BucketcastTUI(base_dir, config_dir)
     app.run()
 
 

--- a/tui/requirements.txt
+++ b/tui/requirements.txt
@@ -1,4 +1,4 @@
-# Sync Shuttle TUI Dependencies
+# Bucketcast TUI Dependencies
 # Install with: pip install -r requirements.txt
 
 # Terminal UI framework

--- a/tui/sync_tui.py
+++ b/tui/sync_tui.py
@@ -477,16 +477,16 @@ class MainScreen(Screen):
         # Main tabbed content
         with TabbedContent(id="main-tabs"):
             with TabPane("Servers", id="tab-servers"):
-                yield self._compose_servers_tab()
+                yield from self._compose_servers_tab()
 
             with TabPane("Inbox", id="tab-inbox"):
-                yield self._compose_inbox_tab()
+                yield from self._compose_inbox_tab()
 
             with TabPane("Outbox", id="tab-outbox"):
-                yield self._compose_outbox_tab()
+                yield from self._compose_outbox_tab()
 
             with TabPane("Activity", id="tab-activity"):
-                yield self._compose_activity_tab()
+                yield from self._compose_activity_tab()
 
         yield Footer()
 

--- a/tui/sync_tui.py
+++ b/tui/sync_tui.py
@@ -44,6 +44,126 @@ except ImportError:
 
 
 # =============================================================================
+# HELP TEXT
+# =============================================================================
+
+HELP_TEXT = """
+[bold cyan]═══════════════════════════════════════════════════════════════════════════════[/bold cyan]
+[bold cyan]                           SYNC SHUTTLE - HELP                                  [/bold cyan]
+[bold cyan]═══════════════════════════════════════════════════════════════════════════════[/bold cyan]
+
+[bold yellow]KEYBOARD SHORTCUTS[/bold yellow]
+────────────────────────────────────────────────────────────────────────────────
+  [bold]p[/bold]         Push a file to a server's inbox
+  [bold]l[/bold]         Pull files from a server's outbox
+  [bold]s[/bold]         Share a file (add to your outbox)
+  [bold]r[/bold]         Refresh the current view
+  [bold]1-5[/bold]       Switch tabs (Servers, Inbox, Outbox, Activity, Help)
+  [bold]?[/bold]         Show quick help notification
+  [bold]q[/bold]         Quit the application
+
+[bold yellow]TABS OVERVIEW[/bold yellow]
+────────────────────────────────────────────────────────────────────────────────
+  [bold]Servers[/bold]   View and manage configured remote servers
+  [bold]Inbox[/bold]     Files received FROM other servers (organized by sender)
+  [bold]Outbox[/bold]    Files shared FOR other servers to pull
+  [bold]Activity[/bold]  Recent sync operations and logs
+  [bold]Help[/bold]      This help screen
+
+[bold yellow]DIRECTORY STRUCTURE[/bold yellow]
+────────────────────────────────────────────────────────────────────────────────
+  ~/.sync-shuttle/
+  ├── config/
+  │   ├── sync-shuttle.conf     Main configuration
+  │   └── servers.toml          Server definitions
+  ├── local/
+  │   ├── inbox/<server>/       Files received from each server
+  │   └── outbox/
+  │       ├── global/           Shared with ALL servers
+  │       └── <server>/         Shared with specific server
+  └── logs/
+      ├── sync.log              Human-readable log
+      └── sync.jsonl            Machine-readable JSON log
+
+[bold yellow]CLI COMMANDS[/bold yellow]
+────────────────────────────────────────────────────────────────────────────────
+  [bold]sync-shuttle init[/bold]
+      Initialize directory structure (run once)
+
+  [bold]sync-shuttle push -s <server> -S <file>[/bold]
+      Push a file to a server's inbox
+      Add --dry-run to preview without executing
+      Add --force to allow overwrites
+
+  [bold]sync-shuttle pull -s <server>[/bold]
+      Pull files from a server's outbox (global + your hostname)
+      Add --dry-run to preview
+
+  [bold]sync-shuttle share --global -S <file>[/bold]
+      Share a file with ALL servers (goes to outbox/global/)
+
+  [bold]sync-shuttle share -s <server> -S <file>[/bold]
+      Share a file with a SPECIFIC server (goes to outbox/<server>/)
+
+  [bold]sync-shuttle share --list[/bold]
+      List all currently shared files
+
+  [bold]sync-shuttle share --remove --global -S <file>[/bold]
+      Remove a file from global share
+
+  [bold]sync-shuttle list servers[/bold]
+      List all configured servers
+
+  [bold]sync-shuttle list files -s <server>[/bold]
+      List files synced with a server
+
+  [bold]sync-shuttle status[/bold]
+      Show sync status and recent operations
+
+  [bold]sync-shuttle tui[/bold]
+      Launch this interactive interface
+
+[bold yellow]WORKFLOW EXAMPLES[/bold yellow]
+────────────────────────────────────────────────────────────────────────────────
+  [bold]Send a file to a colleague:[/bold]
+    sync-shuttle push -s their-server -S ~/document.pdf
+
+  [bold]Receive files from a colleague:[/bold]
+    sync-shuttle pull -s their-server
+    ls ~/.sync-shuttle/local/inbox/their-server/
+
+  [bold]Share a file for anyone to pull:[/bold]
+    sync-shuttle share --global -S ~/shared-notes.txt
+
+  [bold]Check what you're sharing:[/bold]
+    sync-shuttle share --list
+
+[bold yellow]SAFETY FEATURES[/bold yellow]
+────────────────────────────────────────────────────────────────────────────────
+  • All files stay in ~/.sync-shuttle/ (sandboxed)
+  • Files are NEVER deleted by sync-shuttle
+  • Existing files are NEVER overwritten without --force
+  • Use --dry-run to preview any operation
+  • All operations are logged
+
+[bold yellow]CONFIGURATION[/bold yellow]
+────────────────────────────────────────────────────────────────────────────────
+  Edit servers: ~/.sync-shuttle/config/servers.toml
+
+  Example server entry:
+    [servers.myserver]
+    name = "My Server"
+    host = "192.168.1.100"
+    port = 22
+    user = "myuser"
+    remote_base = "/home/myuser/.sync-shuttle"
+    enabled = true
+
+[bold cyan]═══════════════════════════════════════════════════════════════════════════════[/bold cyan]
+"""
+
+
+# =============================================================================
 # DATA MODELS
 # =============================================================================
 
@@ -115,7 +235,7 @@ def load_servers(config_dir: Path) -> List[ServerConfig]:
 
 
 def load_operations(logs_dir: Path, limit: int = 20) -> List[SyncOperation]:
-    """Load recent sync operations."""
+    """Load recent sync operations from JSON log."""
     log_file = logs_dir / "sync.jsonl"
     operations = []
 
@@ -145,6 +265,20 @@ def load_operations(logs_dir: Path, limit: int = 20) -> List[SyncOperation]:
             continue
 
     return operations
+
+
+def load_log_lines(logs_dir: Path, limit: int = 50) -> List[str]:
+    """Load recent lines from human-readable log."""
+    log_file = logs_dir / "sync.log"
+
+    if not log_file.exists():
+        return []
+
+    try:
+        lines = log_file.read_text().strip().split("\n")
+        return lines[-limit:]
+    except:
+        return []
 
 
 def human_size(size: int) -> str:
@@ -642,7 +776,8 @@ class SyncShuttleTUI(App):
         Binding("2", "tab_inbox", "Inbox"),
         Binding("3", "tab_outbox", "Outbox"),
         Binding("4", "tab_activity", "Activity"),
-        Binding("?", "help", "Help"),
+        Binding("5", "tab_help", "Help"),
+        Binding("?", "show_help", "Help"),
     ]
 
     def __init__(self, base_dir: Path, config_dir: Path):
@@ -717,9 +852,9 @@ class SyncShuttleTUI(App):
                     )
 
             with TabPane("Activity", id="tab-activity"):
-                operations = load_operations(self.logs_dir)
                 yield Static("[bold]📊 Recent Activity[/bold]\n", classes="section-title")
-                if not operations:
+                log_lines = load_log_lines(self.logs_dir, limit=30)
+                if not log_lines:
                     yield EmptyState(
                         icon="📊",
                         title="No Activity Yet",
@@ -727,21 +862,21 @@ class SyncShuttleTUI(App):
                         action=""
                     )
                 else:
-                    table = DataTable(id="activity-table")
-                    table.add_columns("Status", "Type", "Server", "Time", "Details")
-                    for op in operations[:15]:
-                        status = "✓" if op.status == "SUCCESS" else "✗"
-                        status_style = "green" if op.status == "SUCCESS" else "red"
-                        op_type = "↑ Push" if op.operation == "push" else "↓ Pull"
-                        time = relative_time(op.timestamp_start)
-                        table.add_row(
-                            Text(status, style=status_style),
-                            op_type,
-                            op.server_id[:15],
-                            time,
-                            op.uuid[:8]
-                        )
-                    yield table
+                    # Show recent log entries
+                    for line in log_lines:
+                        if "[ERROR]" in line:
+                            yield Static(f"[red]{line}[/red]")
+                        elif "[SUCCESS]" in line:
+                            yield Static(f"[green]{line}[/green]")
+                        elif "[WARN]" in line:
+                            yield Static(f"[yellow]{line}[/yellow]")
+                        elif "[INFO]" in line:
+                            yield Static(f"[blue]{line}[/blue]")
+                        else:
+                            yield Static(f"[dim]{line}[/dim]")
+
+            with TabPane("Help", id="tab-help"):
+                yield Static(HELP_TEXT)
 
         yield Footer()
 
@@ -786,9 +921,13 @@ class SyncShuttleTUI(App):
         tabs = self.query_one("#main-tabs", TabbedContent)
         tabs.active = "tab-activity"
 
-    def action_help(self) -> None:
+    def action_tab_help(self) -> None:
+        tabs = self.query_one("#main-tabs", TabbedContent)
+        tabs.active = "tab-help"
+
+    def action_show_help(self) -> None:
         self.notify(
-            "p=Push  l=Pull  s=Share  1-4=Tabs  r=Refresh  q=Quit",
+            "p=Push  l=Pull  s=Share  1-5=Tabs  r=Refresh  q=Quit",
             timeout=5
         )
 

--- a/tui/sync_tui.py
+++ b/tui/sync_tui.py
@@ -628,14 +628,7 @@ class SyncShuttleTUI(App):
         max-height: 100%;
     }
 
-    /* Scrollable areas */
-    ScrollableContainer {
-        height: 100%;
-    }
-
-    #server-list {
-        height: 100%;
-    }
+    /* Scrollable areas - no height constraint, let content size naturally */
     """
 
     TITLE = "Sync Shuttle"


### PR DESCRIPTION
## Problem

The inbox and outbox directories had an **asymmetric design**:
- **Inbox**: Per-server (`inbox/<server_id>/`) - you know WHO sent each file
- **Outbox**: Flat (`outbox/`) - everyone pulls the same files, no control

This created a mental model mismatch:
- "Files I received from server A" → `inbox/serverA/` ✓
- "Files I'm sharing with server A" → `outbox/serverA/` ✗ (didn't exist)

## Solution

New directory structure:
```
~/.sync-shuttle/local/
├── inbox/
│   └── <server_id>/        # Files received FROM this server
└── outbox/
    ├── global/             # Available to all servers
    └── <server_id>/        # Server-specific shares
```

New behavior:
| Operation | Source | Destination |
|-----------|--------|-------------|
| **PUSH** | User file | Remote's `inbox/<your_hostname>/` |
| **SHARE** | User file | Your `outbox/global/` or `outbox/<server_id>/` |
| **PULL** | Remote's `outbox/global/` + `outbox/<your_hostname>/` | Your `inbox/<server_id>/` |

## Changes

- Add `share` command with `--global`, `--list`, `--remove` flags
- Update `pull` to check both `outbox/global/` and `outbox/<hostname>/` on remote
- Add reserved namespace validation ("global" cannot be server ID)
- Add migration for existing `outbox/` files → `outbox/global/`
- Redesign TUI with tabbed navigation and push/pull/share dialogs
- Update documentation (README, SPECIFICATION, --help)

## Test plan

- [ ] `sync-shuttle share --global -S ~/test.txt` → file in `outbox/global/`
- [ ] `sync-shuttle share -s myserver -S ~/test.txt` → file in `outbox/myserver/`
- [ ] `sync-shuttle share --list` → shows all shared files
- [ ] `sync-shuttle share --remove --global -S test.txt` → removes from global
- [ ] `sync-shuttle pull -s <server>` → pulls from global + per-server outbox
- [ ] Server ID "global" is rejected
- [ ] TUI push/pull/share dialogs work