### PR TITLE
Hotfix: errexit crash with post-increment on zero

### DIFF
--- a/lib/s3.sh
+++ b/lib/s3.sh
@@ -279,7 +279,7 @@ cleanup_s3_archives() {
         
         if [[ "$date" < "$cutoff_date" ]]; then
             log_debug "Would delete: $path (from $date)"
-            ((deleted_count++))
+            ((++deleted_count))
         fi
     done
     

--- a/sync-shuttle.sh
+++ b/sync-shuttle.sh
@@ -1123,7 +1123,7 @@ list_servers() {
             "$port"
         printf "    └─ %s\n" "$name"
 
-        ((found_servers++))
+        ((++found_servers))
     done < <("$python" "$parser" "$servers_file" list-detail)
 
     if [[ $found_servers -eq 0 ]]; then

--- a/tests/helpers/mocks.sh
+++ b/tests/helpers/mocks.sh
@@ -77,7 +77,7 @@ get_call_args() {
                 echo "${call#*:}"
                 return
             fi
-            ((count++))
+            ((++count))
         fi
     done
 }


### PR DESCRIPTION
## Bug

`sync-shuttle list servers` only displayed the first configured server, then silently exited.

## Root Cause

```bash
((found_servers++))
```

With `set -o errexit` enabled:
- `((var++))` returns the value BEFORE increment
- When `found_servers=0`, expression returns `0` (falsy)
- Exit code becomes `1`
- `errexit` terminates the script

## Fix

Use pre-increment `((++var))` which returns value AFTER increment:
- When `found_servers=0`, expression returns `1` (truthy)
- Exit code is `0`
- Script continues

## Files Changed

- `sync-shuttle.sh` - `list_servers()` counter
- `lib/s3.sh` - `cleanup_old_archives()` counter  
- `tests/helpers/mocks.sh` - `get_mock_call_args()` counter

## Test

```bash
# Before: only shows first server
sync-shuttle list servers

# After: shows all servers
sync-shuttle list servers
```